### PR TITLE
Adds text on how to create an upgrade macro in your branch

### DIFF
--- a/source/WorkingPractices/inputs.rst
+++ b/source/WorkingPractices/inputs.rst
@@ -40,6 +40,10 @@ UM's metadata :ref:`is available <metadata_guidance>`.
   document in the future, rather than the JULES wiki page
   (https://code.metoffice.gov.uk/trac/jules/wiki/WorkingPractices#NamelistsUpgradeMacrosMetadata)
 
+.. note::
+  JULES developers also need to update the JULES documentation whenever they add or remove
+  namelist variables.
+
 .. important::
   All changes which alter namelists require an upgrade macro for them to
   work with the model.
@@ -60,6 +64,11 @@ the new metadata.
 ..
   The above should probably be extended to LFRic eventually.
 
+How to add an upgrade macro to your branch
+------------------------------------------
+
+Please see :ref:`this page <macros>` for further information.
+
 .. tip::
   When developing a change that updates the input and/or user interface,
   then repeatedly running/reverting the upgrade macro on the dev branch,
@@ -78,3 +87,4 @@ the new metadata.
     :hidden:
 
     metadata_guidance
+    macros

--- a/source/WorkingPractices/macros.rst
+++ b/source/WorkingPractices/macros.rst
@@ -1,0 +1,76 @@
+.. _macros:
+
+Upgrade Macros
+==============
+
+To create an upgrade macro, the developer must edit a ``versions.py`` file which is used
+to update the various apps in the rose stem suite to accept the namelist changes. The upgrade
+macros also form the basis of the ``rose app-upgrade`` script applied by a user wishing to
+upgrade from one version of a model to the next.
+
+The  ``versions.py`` file containing upgrade macros can be found in the following locations:
+
++------------------+----------------------------------------------+
+| Project          | Location                                     |
++==================+==============================================+
+| UM               |  ``rose-meta/um-atmos/versions.py``          |
++------------------+----------------------------------------------+
+| JULES            |  ``rose-meta/jules-standalone/versions.py``  |
++------------------+----------------------------------------------+
+| UKCA / CASIM /   | Upgrade macros not currently used by these   |
+|                  |                                              |
+| LFRic / SOCRATES | projects.                                    |
++------------------+----------------------------------------------+
+
+Within the file a blank upgrade macro will typically look like this:
+
+.. code-block::
+
+  class vn130_tXXXX(MacroUpgrade):
+
+      """Upgrade macro for ticket #XXXX by <author>."""
+
+      BEFORE_TAG = "vn13.0"
+      AFTER_TAG = "vn13.0_tXXXX"
+
+      def upgrade(self, config, meta_config=None):
+          """Upgrade a runtime app configuration."""
+          # Input your macro commands here
+          return config, self.reports
+
+
+Example of an upgrade macro
+---------------------------
+
+Developer Sally Smith wishes to add the logical ``l_bugfix`` to the
+``&run_bl`` namelist in the UM. To do this, she replaces the `XXXX`
+line in the upgrade macro with her ticket number and adds herself
+as the author. Within the Python function ``upgrade``, she adds the
+appropriate command to include the new logical. The macro then looks
+like this:
+
+.. code-block::
+
+  class vn130_t1234(MacroUpgrade):
+
+      """Upgrade macro for ticket #1234 by Sally Smith."""
+
+      BEFORE_TAG = "vn13.0"
+      AFTER_TAG = "vn13.0_t1234"
+
+      def upgrade(self, config, meta_config=None):
+          """Add l_bugfix to namelist run_bl"""
+          self.add_setting(config, ["namelist:run_bl", "l_bugfix"], ".true.")
+          return config, self.reports
+
+Note that the settings added and their values are Python **strings**.
+This command can then be run on a **test** branch (see :ref:`testing`).
+
+.. note::
+
+  Further information about upgrade macros can be found in the
+  `Rose user guide <http://metomi.github.io/rose/doc/html/api/rose-upgrader-macros.html>`_.
+  This contains information about more complex changes, such as removing variables from
+  namelists and changing the value that a particular variable takes.
+  A `tutorial <http://metomi.github.io/rose/doc/html/tutorial/rose/furthertopics/upgrading.html>`_
+  is also available.


### PR DESCRIPTION
Details of how to create an upgrade macro in your branch have been added, along with a link of the appropriate page and a little bit of missing information on the JULES documentation needing updating when the developer alters namelists.

Closes #32 .