### PR TITLE
Setup GitHub actions

### DIFF
--- a/.github/workflows/publish_wps.yml
+++ b/.github/workflows/publish_wps.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
     - main
-    - setup_github_actions
     
   workflow_dispatch:
   


### PR DESCRIPTION
Closes #20 

Working practices documentation can be published by uploading fresh html to the gh-pages branch. Here I attempt to set up a Github Action to do that automatically whenever fresh code is pushed to main.

New action has successfully run to completion (triggered from a push to this branch - I've removed that now so only commits to MAIN will trigger it). I can see the gh-pages branch has a fresh commit and the deployment to pages has run successfully too. Ultimate test will be when we get a fresh push to main with this live. 
