### PR TITLE
Update testing to make multi-repo links clearer

### DIFF
--- a/source/WorkingPractices/TestSuites/jules.rst
+++ b/source/WorkingPractices/TestSuites/jules.rst
@@ -15,6 +15,12 @@ several configurations, and rose-ana tasks to check the output.
 The output is checked for correctness both by comparing the output to a set of
 stored :ref:`KGO files <kgo>`.
 
+.. note::
+    If there are JULES changes to shared science code or metadata then these
+    changes will need to be tested using the UM and LFRic test-suites too.
+
+    See :ref:`multirepo` for details on how to carry out this testing.
+
 Below is a (by no means comprehensive) set of groups that you may wish to use on
 Met Office systems.
 
@@ -45,4 +51,3 @@ Met Office systems.
     |                    |                                                          |
     |                    | compiler.                                                |
     +--------------------+----------------------------------------------------------+
-

--- a/source/WorkingPractices/TestSuites/ukca.rst
+++ b/source/WorkingPractices/TestSuites/ukca.rst
@@ -2,7 +2,7 @@ Testing UKCA
 ============
 
 Changes in UKCA that touch `src/science` or `src/control/core` must be tested
-with both the UM and LFRic by following the :ref:`linked tickets guidance <linked>`.
+with both the UM and LFRic by following the :ref:`linked tickets guidance <multirepo>`.
 
 For further guidance on testing and working with UKCA, including standard
 suites and box models see

--- a/source/WorkingPractices/TestSuites/um.rst
+++ b/source/WorkingPractices/TestSuites/um.rst
@@ -32,6 +32,12 @@ restarted.
 
         rose stem --group=xc40_gnu_um_rigorous_omp-n48
 
+.. note::
+    If there are UM changes to src/atmosphere code or metadata then these
+    changes will need to be tested using the LFRic test-suites too.
+
+    See :ref:`multirepo` for details on how to carry out this testing.
+
 Below is a (by no means comprehensive) set of groups that you may wish to use on
 Met Office systems. Note that there is a lot of overlap between these groups,
 and that you can specify more than one at once, e.g. ``--group=developer,jules,ukca``.
@@ -91,4 +97,3 @@ and that you can specify more than one at once, e.g. ``--group=developer,jules,u
     The `standard jobs <https://code.metoffice.gov.uk/trac/um/wiki/StandardJobs>`_
     page for each release includes details of which of ``developer``,
     ``nightly`` and ``all`` a configuration is tested at.
-

--- a/source/WorkingPractices/branches.rst
+++ b/source/WorkingPractices/branches.rst
@@ -55,6 +55,8 @@ Where ``NNN`` should be replaced by the ticket number. Saving and exiting the te
 will produce a message in the terminal asking whether the user really wants to create the branch.
 Enter ``y`` to continue.
 
+.. _checkout:
+
 Checking out a branch to a working copy
 ---------------------------------------
 

--- a/source/WorkingPractices/multi_repository.rst
+++ b/source/WorkingPractices/multi_repository.rst
@@ -35,7 +35,7 @@ Do:
     * Get the tickets ready for review at the same time
     * Ask for help testing if you don't have access to all the codebases involved
 
-.. note::
+.. important::
     Code branches in linked tickets will require branching from compatible revisions
     to ensure they work together.
 
@@ -66,11 +66,19 @@ Testing the UM with other repositories
 
 To test the UM, any changes to JULES, UKCA, Socrates, CASIM etc will also need
 to be included. This is done by adding another source to the rose stem command
-line. So from a UM working copy at a suitable revision:
+line.
 
-    .. code-block::
+    1. :ref:`Checkout<checkout>` a UM working copy
 
-        rose stem --group=developer,jules,ukca --source=. --source=/path/to/jules/changes --source=/path/to/ukca/changes
+        - this may be your branch from a linked ticket, or a clean trunk copy
+          at either the last release or a suitable head of trunk revision.
+
+    2. Run rose stem, including groups that cover the repositories being tested
+       and a source code path to every branch involved.
+
+        .. code-block::
+
+            rose stem --group=developer,jules,ukca --source=. --source=/path/to/jules/changes --source=/path/to/ukca/changes
 
 The source paths involved can either be to local working copies or links to the
 fcm source control e.g. ``fcm:jules.xm_br/dev/user/branch_name``. As many source
@@ -84,14 +92,23 @@ to the other codebases involved should be added to
 ``lfric_atm/fcm-make/parameters.sh`` under each of the ``*_sources`` variables. Again
 these paths can either be to local changes or those in the repository.
 
-e.g. from an LFRic working copy at a suitable revision:
+    1. :ref:`Checkout<checkout>` an LFRic working copy
 
-    .. code-block:: RST
+        - this may be your branch from a linked ticket, or a clean trunk copy
+          at either the last release or a suitable head of trunk revision.
 
-        um_sources=vldXXX:/path/to/um/working/copy
+    2. Update parameters.sh to point to all other code changes
 
-Once parameters.sh has been updated you can run `make test-suite` as described
-:ref:`here <lfric_test>`.
+        .. code-block:: RST
+
+            um_sources=vldXXX:/path/to/um/working/copy
+            jules_source=vldXXX:/path/to/jules/working/copy
+
+    3. Run test-suite
+
+        .. code-block::
+
+            `make test-suite`
 
 
 .. tip::


### PR DESCRIPTION
Minor changes to the testing pages to help highlight multirepository testing and clarify the process for each.