### PR TITLE
The publish_wps.yml workflow requires a "git add" step

### DIFF
--- a/.github/workflows/publish_wps.yml
+++ b/.github/workflows/publish_wps.yml
@@ -40,5 +40,6 @@ jobs:
         git fetch origin gh-pages 
         git checkout gh-pages
         cp -r ../simulation-systems/build/html/. .
+        git add .
         git commit -am "Docs build"
         git push -u origin gh-pages


### PR DESCRIPTION
Closes #98 