### PR TITLE
Fix trivial typo in rose stem incantation

### DIFF
--- a/source/Reviewers/howtocommit.rst
+++ b/source/Reviewers/howtocommit.rst
@@ -272,8 +272,8 @@ are no clashes with what else has gone on trunk.
 
             export CYLC_VERSION=8
 
-            rose-stem --group=developer
-            OR e.g. rose-stem --group=developer,gungho_model
+            rose stem --group=developer
+            OR e.g. rose stem --group=developer,gungho_model
 
             cylc play <working copy name>
 


### PR DESCRIPTION
Trvial PR to fix a typo in example incantations for rose stem.