### PR TITLE
Add suite report instructions

### DIFF
--- a/source/WorkingPractices/testing.rst
+++ b/source/WorkingPractices/testing.rst
@@ -122,3 +122,18 @@ included when passing a ticket for review.
 .. code-block::
 
     ~/cylc-run/<suite_name>/trac.log
+
+
+.. tip::
+    If your suite has finished and no trac.log has been generated then it is
+    possible to do so manually using
+    `suite_report.py <https://github.com/MetOffice/SimSys_Scripts/blob/main/suite_report.py>`_.
+
+    On Met Office desktops a copy is stored locally allowing this to be done with:
+
+    .. code-block::
+
+        python3 $UMDIR/SimSys_Scripts/suite_report.py -S <workflow path>
+
+    If this is a regular problem then get in touch with the :ref:`SSD team <ssd>` so we can
+    investigate. Thanks.

--- a/source/WorkingPractices/who.rst
+++ b/source/WorkingPractices/who.rst
@@ -130,7 +130,9 @@ Core Capability Development Team
 The Core Capability Development Team are responsible for the LFRic Infrastructure to
 support the Next Generation Modelling Systems.
 
-LFRic questions can be directed to meto-lfric@metoffice.gov.uk.
+The team can be contacted at corecapabilitydevelopmentteam@metoffice.gov.uk.
+
+LFRic questions can also be directed to meto-lfric@metoffice.gov.uk.
 .. todo: flesh out the description here
 
 .. _hpc_opt_team:


### PR DESCRIPTION
Some LFRic Apps users are having problems with suite_report so adding manual trigger instructions to help. 

Also adding CCD email address since this didn't exist when that section was last editted. 
