### PR TITLE
Added no AI clauses to Working Practices

### DIFF
--- a/source/FurtherDetails/dos_donts.rst
+++ b/source/FurtherDetails/dos_donts.rst
@@ -44,6 +44,11 @@ has been developed under a different license without agreement from the
 Simulation Systems and Deployment Team. This includes lifting Fortran code or
 text from books. Our repositiories must not infringe copyright.
 
+**Do not add AI-generated code** even in a fork or branch. AI tools such as Github 
+CoPilot are becoming more readily available. However, the detailed terms and 
+conditions associated with these need to be evaluated for compatibility with 
+licensing and copyright.
+
 **Add or link to old code** or tickets that predate MOSRS, for example...
 
 * Link to tickets in old internal repositories- links will either not resolve or be incorrect

--- a/source/WorkingPractices/developing_change.rst
+++ b/source/WorkingPractices/developing_change.rst
@@ -24,6 +24,9 @@ Commits to your branch should take the following form in their log messages:
   it is useful to have an appropriate coding plan in place.
   See :ref:`planning` for further details.
 
+.. note::
+  Do not add AI-generated code, eg from GitHub CoPilot to any branches or forks.
+
 Code changes should conform to the coding standards of the project.
 Remember to ensure that your changes are easy to read and follow, using
 comments to explain what the code is doing.


### PR DESCRIPTION
Following discussions of internal Met Office guidance, the WPs need a tweak to be explicit about use of AI generated code.