### PR TITLE
Clarify the meaning of author in commit messages

### DIFF
--- a/source/Reviewers/howtocommit.rst
+++ b/source/Reviewers/howtocommit.rst
@@ -534,7 +534,7 @@ An editor will open requesting a log message which should be in this format:
 
             #ticket_number : Author : Ticket title
 
-        where author is the srs username.
+        where author is the SRS username of the developer - usually the Reported By field on the ticket.
 
     .. tab-item:: LFRic Core
 
@@ -542,7 +542,7 @@ An editor will open requesting a log message which should be in this format:
 
             #<ticket number> for <original author>: <ticket title>
 
-        where original author is the authors proper name.
+        where original author is the dveloper's proper name.
 
 .. note::
      New!! Remove any **blocks:** and **blockedby:** keywords from this ticket and any referenced. Comment on any unblocked tickets to alert the developers.


### PR DESCRIPTION
The instructions did not explicitly state that the author field in the commit message was the original developer of the change.  This adjusts the wording of both the LFRic and non-LFRic sections to make the meaning clear.