### PR TITLE
Accessibility - Are all links clear and descriptive (WCAG 2.4.4)

### DIFF
--- a/source/FurtherDetails/glossary.rst
+++ b/source/FurtherDetails/glossary.rst
@@ -73,7 +73,7 @@ SciTech Review:
 
 Simulation Systems and Deployment Team:
     The team responsible for the oversight of these working practices. For
-    more information see here :ref:`ssd`
+    more information see :ref:`ssd`.
 
 Simulation Systems Governance Group:
     The governing body that oversees the work of the Simulation Systems and

--- a/source/FurtherDetails/who.rst
+++ b/source/FurtherDetails/who.rst
@@ -71,7 +71,7 @@ Sci/Tech Reviewer
 
 A Sci/Tech reviewer is assigned for every ticket and comprises the first stage
 of review that considers the change as a whole. Further details are linked from
-the Working Practices :ref:`here <scitech>`. In some cases, the reviewer can
+the :ref:`Working Practices page<scitech>`. In some cases, the reviewer can
 delegate parts of the work to another person.
 
 Reviews should be turned around on a reasonable timescale and follow the SciTech
@@ -87,7 +87,7 @@ Code Reviewer
 -------------
 
 The Code Reviewer performs the 2nd stage of review for every ticket.
-Further details are described :ref:`here <codereview>`.
+Further details are described :ref:`Working Practices page<codereview>`.
 
 Reviews should be turned around on a reasonable timescale and follow the Code
 Review guidance.

--- a/source/Reviewers/committinglinkedtickets.rst
+++ b/source/Reviewers/committinglinkedtickets.rst
@@ -44,7 +44,8 @@ Testing linked tickets
 With the branches from all the tickets merged into a working copy of their
 respective Head of Trunk these can all be used together to test the change.
 
-Details for testing multi-repository tickets are included :ref:`here <multirepo>`.
+Details for testing multi-repository tickets are included on the
+:ref:`Working with Multiple Repositories page<multirepo>`.
 
 **In summary:**
 

--- a/source/Reviewers/howtocommit.rst
+++ b/source/Reviewers/howtocommit.rst
@@ -213,7 +213,8 @@ even trivial tickets to check that the merge has not caused issues, or that ther
 are no clashes with what else has gone on trunk.
 
 .. note::
-    Linked tickets will need to be tested together as discussed :ref:`here <tesinglinked>`.
+    Linked tickets will need to be tested together as discussed
+    on the :ref:`Committing Linked Tickets page<tesinglinked>`.
 
 .. tab-set::
 

--- a/source/WorkingPractices/TestSuites/lfric_core.rst
+++ b/source/WorkingPractices/TestSuites/lfric_core.rst
@@ -38,6 +38,5 @@ It is also possible to select the platform to run on. Available options include
 .. tip::
 
     For more details on LFRic testing including details of unit tests please
-    visit the trac wiki
-    `here <https://code.metoffice.gov.uk/trac/lfric/wiki/LFRicTechnical/Testing>`_.
+    visit the `LFRic testing trac wiki page <https://code.metoffice.gov.uk/trac/lfric/wiki/LFRicTechnical/Testing>`_.
 

--- a/source/WorkingPractices/TestSuites/multi-repo_testing.rst
+++ b/source/WorkingPractices/TestSuites/multi-repo_testing.rst
@@ -7,7 +7,7 @@ Multi-repository changes are expected to pass the regression tests for all the
 repositories involved. To carry out the tests involved in a linked ticket it can
 be helpful to refer to the :ref:`semi-concentric circles figure <multirepo>`; layering the testing
 from the inside out as needed. Further details of how testing in each
-repository is handled can be found :ref:`here <testing>`. Compatible
+repository is handled can be found on the :ref:`Testing page<testing>`. Compatible
 code revisions are needed for testing across repositories as described above.
 
 Testing changes in JULES, LFRic Core, UKCA, or any other child repositories is
@@ -89,7 +89,8 @@ these paths can either be to local changes or those in the repository.
     cylc play <working copy name>
     cylc gui
 
-More details on LFRic Apps testing are found :ref:`here<lfric_apps_test>`.
+More details on LFRic Apps testing are found on the 
+:ref:`Testing LFRic Apps page<lfric_apps_test>`.
 
 .. note::
     If any of the testing shows up failures then there are two possible ways to

--- a/source/WorkingPractices/TestSuites/ukca.rst
+++ b/source/WorkingPractices/TestSuites/ukca.rst
@@ -5,5 +5,5 @@ Changes in UKCA that touch `src/science` or `src/control/core` must be tested
 with both the UM and LFRic by following the :ref:`linked tickets guidance <multirepo>`.
 
 For further guidance on testing and working with UKCA, including standard
-suites and box models see
-`here <https://code.metoffice.gov.uk/trac/ukca/wiki/WorkingPractices>`_
+suites and box models see the 
+`UKCA trac wiki<https://code.metoffice.gov.uk/trac/ukca/wiki/WorkingPractices>`_.

--- a/source/WorkingPractices/documentation.rst
+++ b/source/WorkingPractices/documentation.rst
@@ -15,7 +15,7 @@ Most notably:
 
 LFRic Apps and Core also use doxygen to document the code and all changes should
 include appropriate doxygen changes to go with them. Doxygen guidelines are
-available `here <https://code.metoffice.gov.uk/trac/lfric/wiki/LFRicTechnical/DoxygenUsage>`_.
+available on the `LFRic Technical pages<https://code.metoffice.gov.uk/trac/lfric/wiki/LFRicTechnical/DoxygenUsage>`_.
 
 .. toctree::
     :hidden:

--- a/source/WorkingPractices/kgo.rst
+++ b/source/WorkingPractices/kgo.rst
@@ -78,7 +78,7 @@ such changes onto the trunk. When preparing your change for review:
 
 .. tip::
     More details on the KGO update proceedures for all repositories can be found
-    :ref:`here <kgo_instructions>`.
+    on the :ref:`How to Commit page<kgo_instructions>`.
 
 .. toctree::
     :hidden:

--- a/source/WorkingPractices/reviews.rst
+++ b/source/WorkingPractices/reviews.rst
@@ -96,7 +96,8 @@ fill in a :ref:`SciTech Review Checklist <template>` which makes sure all
 aspects of the ticket are considered. Once the reviewer is satisfied, they will
 pass the ticket on to code/system review.
 
-Guidance for the SciTech reviewer can be found :ref:`here <scitech_review>`.
+Guidance for the SciTech reviewer can be found on the 
+:ref:`SciTech review page <scitech_review>`.
 
 .. _codereview:
 
@@ -119,7 +120,8 @@ will be needed in this case.
 Once the code reviewer is satisfied they will move the ticket into the `approved`
 state, ready for commit to the trunk.
 
-Guidance for the code reviewer can be found :ref:`here <code_review>`.
+Guidance for the code reviewer can be found on the 
+:ref:`Code Review page <code_review>`.
 
 -----
 


### PR DESCRIPTION
Change links from `here` to be verbose for screen readers.