### PR TITLE
Add in Crown Copyright

### DIFF
--- a/source/_templates/crown-copyright.html
+++ b/source/_templates/crown-copyright.html
@@ -1,0 +1,12 @@
+{# Displays the copyright information (which is defined in conf.py). #}
+{% if show_copyright and copyright %}
+<p class="copyright">
+    {% if hasdoc('copyright') %}
+    {% trans path=pathto('copyright'), copyright=copyright|e %}© <a href="{{ path }}">Crown Copyright, </a> {{ copyright }}.{% endtrans %}
+    <br/>
+    {% else %}
+    {% trans copyright=copyright|e %}© Crown Copyright, {{ copyright }}.{% endtrans %}
+    <br/>
+    {% endif %}
+</p>
+{% endif %}

--- a/source/conf.py
+++ b/source/conf.py
@@ -15,7 +15,7 @@ import datetime
 # -- Project information -----------------------------------------------------
 
 project = 'Simulation Systems'
-copyright = f'{datetime.datetime.now().year},  Met Office'
+copyright = f'Met Office 2024'
 author = 'Simulation Systems and Deployment Team'
 
 
@@ -51,7 +51,7 @@ html_css_files = ["custom.css"]
 html_theme = 'pydata_sphinx_theme'
 
 html_theme_options = {
-    "footer_start": ["copyright", "sphinx-version"],
+    "footer_start": ["crown-copyright", "sphinx-version"],
     "navigation_with_keys": False,
     "show_toc_level": 2,
     "show_prev_next": True,

--- a/source/conf.py
+++ b/source/conf.py
@@ -15,7 +15,7 @@ import datetime
 # -- Project information -----------------------------------------------------
 
 project = 'Simulation Systems'
-copyright = f'Met Office 2024'
+copyright = f'Met Office 2023'
 author = 'Simulation Systems and Deployment Team'
 
 


### PR DESCRIPTION
The copyright notice should say *Crown Copyright*. This updates the template the same way we do in the common Fortran template and LFRic Core repos.

I'm not sure if this is what Rich was referring to in #178 but I have removed the code which updates the year in the copyright as you normally only add years with major revisions and shouldn't really remove the year the docs were first published. Happy to clarify with legal on this if needed.