### PR TITLE
unify GA and local doc build

### DIFF
--- a/.github/workflows/publish_wps.yml
+++ b/.github/workflows/publish_wps.yml
@@ -22,7 +22,7 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - name: Install Dependecies
+    - name: Install Dependencies
       run: |
         pip install -r .github/workflows/requirements.txt
 

--- a/.github/workflows/publish_wps.yml
+++ b/.github/workflows/publish_wps.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     types: [opened,reopened,review_requested]
   workflow_dispatch:
-  
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -22,23 +22,20 @@ jobs:
     - uses: actions/setup-python@v5
       with:
         python-version: '3.x'
-    - name: Install Sphinx packages
+    - name: Install Dependecies
       run: |
-         pip install Sphinx==6.2.1
-         pip install sphinx-design==0.5.0
-         pip install pydata-sphinx-theme
-         pip install sphinx-sitemap
-         
+        pip install -r .github/workflows/requirements.txt
+
     - name: build docs
       run: |
         make clean html
-        
+
     - name: commit docs to gh-pages branch
       if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       run: |
         git worktree add ../publish_wps
         cd ../publish_wps
-        git fetch origin gh-pages 
+        git fetch origin gh-pages
         git checkout gh-pages
         cp -r ../simulation-systems/build/html/. .
         git add .

--- a/.github/workflows/requirements.txt
+++ b/.github/workflows/requirements.txt
@@ -1,0 +1,4 @@
+Sphinx==6.2.1
+sphinx-design==0.5.0
+pydata-sphinx-theme
+sphinx-sitemap

--- a/env.yml
+++ b/env.yml
@@ -1,6 +1,6 @@
 name: sphinx_doc_env
 dependencies:
-  - Sphinx==6.2.1
-  - sphinx-design==0.5.0
-  - pydata-sphinx-theme
-  - sphinx-sitemap
+  - python>=3
+  - pip
+  - pip:
+    - -r .github/workflows/requirements.txt

--- a/source/WorkingPractices/testing.rst
+++ b/source/WorkingPractices/testing.rst
@@ -75,7 +75,7 @@ commands, noting that ``--jules-path`` is only required if you have
 :ref:`guidance<shared-namelists>`.
 
 +-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
-| UM    | ``./admin/rose-stem/update_all.py --path=/path/to/working/copy/of/test/branch --um=vnX.X_tXXXX [--jules-path=/path/to/jules/working/copy/of/branch]``          |
+| UM    | ``./admin/rose-stem/update_all.py --path=/path/to/working/copy/of/test/branch --um=vnX.X_tXXXX [--jules-path=/path/to/jules/working/copy/of/branch]``                        |
 +-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
 | JULES | ``./bin/upgrade_jules_test_apps vnX.X_tXXXX``                                                                                                                                |
 +-------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
It appears that we have sphinx dependencies included in multiple places: GitHub Action workflow for doc build for gh-pages and `env.yml` for local build.  In this PR I've put all dependencies in one place `.github/workflows/requirements.txt` and amended a malformed rst table. 