### PR TITLE
update apps groups and fix typo

### DIFF
--- a/source/Reviewers/howtocommit.rst
+++ b/source/Reviewers/howtocommit.rst
@@ -565,8 +565,8 @@ As reviewer, you should work with the developer, prior to moving to the commit s
 #. Run relevant tests on XCS.
 #. Wait for the daily `cron` job to run to synchronise data between `XCS` `XCE/F` & `SPICE`
 #. Ensure that you are in charge of the in charge of the trunk for the repositories involved.
-# Update your working copy if other commits have happened.
-#. Rerun relevant tests on `XCE/F` and `SPICE` 
+#. Update your working copy if other commits have happened.
+#. Rerun relevant tests on `XCE/F` and `SPICE`
 
 If the requirement is to update existing files, then further care is required.
 
@@ -581,7 +581,7 @@ If the requirement is to update existing files, then further care is required.
 
     - Waiting for the daily `cron` job to run can introduce a misalignment or race condition for scheduled testing.
 
-#. Rerun relevant tests on `XCE/F` and `SPICE` 
+#. Rerun relevant tests on `XCE/F` and `SPICE`
 
     - revert changes immediately if there are any issues, and consult with the developer.
 

--- a/source/WorkingPractices/TestSuites/lfric_apps.rst
+++ b/source/WorkingPractices/TestSuites/lfric_apps.rst
@@ -56,13 +56,8 @@ and that you can specify more than one at once, e.g. ``--group=developer,gungho_
 |                    | to pass before commit. It is a useful checkpoint during  |
 |                    | development.                                             |
 +--------------------+----------------------------------------------------------+
-| nightly            | More thorough testing group. This includes everything in |
-|                    | developer plus some longer and more complex tests. It is |
-|                    | run automatically every night and monitored by the SSD   |
-|                    | team.                                                    |
-+--------------------+----------------------------------------------------------+
 | all                | The complete test suite, including all longer runs and   |
-|                    | less commonly used utilites. This is run automatically   |
+|                    | less commonly used configs. This is run automatically    |
 |                    | every week and monitored by the SSD team. All            |
 |                    | :ref:`KGO <kgo>` changing tickets need to run this group.|
 +--------------------+----------------------------------------------------------+


### PR DESCRIPTION
Remove nightly group from LFRic Apps instructions and fix typo in howtocommit