### PR TITLE
clarify .xm_ for sources

### DIFF
--- a/source/WorkingPractices/TestSuites/lfric_apps.rst
+++ b/source/WorkingPractices/TestSuites/lfric_apps.rst
@@ -27,7 +27,7 @@ Local testing:
 
     When specifying the lfric_core source the lfric_core revision **must** be updated in ``dependencies.sh``.
 
-    * If setting the source to an fcm URL, the mirror needs to be used and the revision can either be blank (for latest commit) or any valid revision for that branch.
+    * If setting the source to an fcm URL, the mirror (``.xm_``) needs to be used and the revision can either be blank (for latest commit) or any valid revision for that branch.
     * If setting the source to a Working Copy, the hostname needs to be provided (as Hostname:Path) and the revision must be blank.
 
     For more details, see :ref:`multi-repo_testing`.

--- a/source/WorkingPractices/TestSuites/multi-repo_testing.rst
+++ b/source/WorkingPractices/TestSuites/multi-repo_testing.rst
@@ -17,7 +17,7 @@ as simple as running the standalone test procedures for these codebases.
 
     When specifying an alternative source in the ``dependencies.sh`` file the revision for the source **must** be updated.
 
-    * If setting the source as an fcm URL, the mirror needs to be used and the revision can either be blank (for latest commit) or any valid revision for that branch.
+    * If setting the source as an fcm URL, the mirror (``.xm_``) needs to be used and the revision can either be blank (for latest commit) or any valid revision for that branch.
     * If setting the source as a Working Copy, the hostname needs to be provided (as Hostname:Path) and the revision must be blank.
 
 Testing the UM with other repositories


### PR DESCRIPTION
Clarify that `.xm_` is required when specifying an fcm source in a dependencies.sh file