### PR TITLE
Added note about ticket numbers on macro upgrade instructions

### DIFF
--- a/source/WorkingPractices/macros.rst
+++ b/source/WorkingPractices/macros.rst
@@ -43,6 +43,11 @@ Within the file a blank upgrade macro will typically look like this:
           # Input your macro commands here
           return config, self.reports
 
+Note: The BEFORE_TAG should match the AFTER_TAG of the previous macro in the chain. So if this is not the first macro since the release then the BEFORE_TAG will be the version number with an added ticket number as well. For example:
+
+.. code-block::
+
+      BEFORE_TAG = "vn13.0_t123"
 
 Example of an upgrade macro
 ---------------------------


### PR DESCRIPTION
The Reviewer section of the guides already had a note about "adding ticket numbers onto a before tag" when adding upgrade macros. However there was no note about this in the Developer section, where there is a template. So I have just added this in under the template, to make it clearer for developers.