### PR TITLE
port release curation notes

### DIFF
--- a/source/Reviewers/curaterelease.rst
+++ b/source/Reviewers/curaterelease.rst
@@ -66,147 +66,118 @@ Open a UM X.Y release Curation Ticket, and assign tasks as a team,
 
 
 Pre-Release
-===========
+-----------
 
-Test Release
-------------
+:ref:`UM Test Release<um_test_release>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 The point of the test release is to test the release system/process works before we have to do it for real. Typically aim for 1-2 weeks before release day. However, before a test release can be done, all changes to fcm-make config files, major rose-stem changes (things like basic upgrade macro or KGO updates don't necessarily need to be included) and modifications to the release_new_version.py script need to be on trunk, so this will cause some variation as to when the test release is done from release to release.
 
-:ref:`UM Test Release<um_test_release>`
 
-
-Partner Testing
----------------
+`Partner Testing <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#PartnerTesting-72hourfreeze>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 All source code changes must be on trunk along with any rose-stem changes that affect multiple sites before partner testing can start. Ideally the test release will also have been completed.
 
-`Partner Testing <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#PartnerTesting-72hourfreeze>`_
 
-
-Scientific Software Stack Update
---------------------------------
+`Scientific Software Stack Update <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#ScientificSoftwareStackUpdate>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 Any potential changes to platform software stacks
 
-`Scientific Software Stack Update <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#ScientificSoftwareStackUpdate>`_
-
 
 Main Release
-============
+------------
 
-Jules Release
--------------
+`Jules Release <https://code.metoffice.gov.uk/trac/jules/wiki/CuratingARelease>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 Partner Testing, All Jules tickets committed
 
-`Jules Release <https://code.metoffice.gov.uk/trac/jules/wiki/CuratingARelease>`_
 
-
-Mule and Shumlib Releases
--------------------------
+`Mule and Shumlib Releases <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#ShumlibMulereleases>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 All tickets affecting Shumlib or Mule should have been committed.
 
-`Mule and Shumlib Releases <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#ShumlibMulereleases>`_
 
-
-Main UM Release
----------------
+:ref:`UM Main Release<um_main_release>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 All UM Tickets, Test Release, Partner Testing, Jules Release
 
-:ref:`UM Main Release<um_main_release>`
 
-
-LFRic Apps Release
-------------------
+:ref:`LFRic Apps Release<lfric_apps_release>`
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 All LFRic Tickets (Apps + Core), Jules Release
 
-:ref:`LFRic Apps Release<lfric_apps_release>`
-
 
 Post Release Tasks
-==================
+------------------
 
-Release Notes
--------------
+`Release Notes <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#ReleaseNotes>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 Most of this can be done pre-release but some details of revision numbers will be dependent on the main release being done.
 
-`Release Notes <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#ReleaseNotes>`_
 
-
-Upgrading Standalone Suites
----------------------------
+`Upgrading Standalone Suites <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#UpgradingStandaloneSuites>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 UM Release (for UM suites), Apps Release (for Apps suites)
 
-`Upgrading Standalone Suites <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#UpgradingStandaloneSuites>`_
-
-
-Standard Jobs Page
-------------------
-
-**Dependencies**
-UM Release
 
 `Standard Jobs Page <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#FinalizeTheStandardJobspage>`_
-
-
-Code and Stash Browsers
------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 UM Release
 
+
 `Code and Stash Browsers <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#InstallCodeandStashbrowsers>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+**Dependencies**
+UM Release
 
 
-UMDP Release
-------------
+`UMDP Release <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#UMDPrelease>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 UM Release, Standard Suites Upgrade
 
-`UMDP Release <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#UMDPrelease>`_
 
-
-Update Wikis, Working Practices, Create Bit Comp Table
-------------------------------------------------------
+`Wikis Update <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Updatewikisworkingpracticesandcreatebitcomptable>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 UM Release
 
-`Wikis Update <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Updatewikisworkingpracticesandcreatebitcomptable>`_
 
-
-Review Shared Account Permissions
----------------------------------
+`Shared Account Permissions <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Reviewandupdatetrunkandsharedaccountpermissions>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 **Dependencies**
 None
 
-`Shared Account Permissions <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Reviewandupdatetrunkandsharedaccountpermissions>`_
 
-
-Creating an Interim Release
----------------------------
+Mid-Release Tasks
+-----------------
 
 `Creating an Interim Release <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Creatinganinterimrelease>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
-Installing New Prebuilds
-------------------------
 
 `Installing New Prebuilds <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Installingnewprebuilds>`_
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/source/Reviewers/curaterelease.rst
+++ b/source/Reviewers/curaterelease.rst
@@ -1,8 +1,188 @@
 Curating a Release
 ==================
 
-Details on how to release each repository can be found on the individual wikis:
+.. toctree::
+    :maxdepth: 1
 
-`Curating a UM Release <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease>`_
+    releases/um_test_release
+    releases/um_main_release
+    releases/lfric_apps_release
 
-`Curating a JULES Release <https://code.metoffice.gov.uk/trac/jules/wiki/CuratingARelease>`_
+
+Release Ticket
+--------------
+
+Open a UM X.Y release Curation Ticket, and assign tasks as a team,
+
+.. code-block::
+
+    The following tickets are required to deliver UM vnX.Y:
+
+    ||= Led by... =||= Description                                                                   =||= Ticket # =||
+    ||||||'''Pre release'''||
+    ||  || Test release                                                                               ||  ||
+    ||  || Partner testing                                                                            ||  ||
+    ||  || Scientific Software Stack Update                                                           ||  ||
+    ||||||'''Release'''||
+    ||  || JULES umX.Y release - [jules:wiki:CuratingARelease]                                        ||  ||
+    ||  || Shumlib + Mule releases                                                                    ||  ||
+    ||  || Build and install the main release                                                         ||  ||
+    ||  || LFRic Apps Release                                                                         ||  ||
+    ||||||'''Post Release'''||
+    ||  || Release notes                                                                              ||  ||
+    ||  || Update standard suites & finalise std jobs page                                            ||  ||
+    ||  || Update $UMDIR scripts                                                                      ||  ||
+    ||  || Check resource monitoring scripts still work                                               ||  ||
+    ||  || Install Code and Stash browsers                                                            ||  ||
+    ||  || UMDP3 Release                                                                              ||  ||
+    ||  || Update wikis, working practices, and create bit comp table                                 ||  ||
+    ||  || Review and update trunk and shared account permissions                                     ||  ||
+
+    [wiki:CuratingARelease Curating a release Page]
+
+
+Pre-Release
+===========
+
+Test Release
+------------
+
+**Dependencies**
+The point of the test release is to test the release system/process works before we have to do it for real. Typically aim for 1-2 weeks before release day. However, before a test release can be done, all changes to fcm-make config files, major rose-stem changes (things like basic upgrade macro or KGO updates don't necessarily need to be included) and modifications to the release_new_version.py script need to be on trunk, so this will cause some variation as to when the test release is done from release to release.
+
+:ref:`UM Test Release<um_test_release>`
+
+
+Partner Testing
+---------------
+
+**Dependencies**
+All source code changes must be on trunk along with any rose-stem changes that affect multiple sites before partner testing can start. Ideally the test release will also have been completed.
+
+`Partner Testing <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#PartnerTesting-72hourfreeze>`_
+
+
+Scientific Software Stack Update
+--------------------------------
+
+**Dependencies**
+Any potential changes to platform software stacks
+
+`Scientific Software Stack Update <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#ScientificSoftwareStackUpdate>`_
+
+
+Main Release
+============
+
+Jules Release
+-------------
+
+**Dependencies**
+Partner Testing, All Jules tickets committed
+
+`Jules Release <https://code.metoffice.gov.uk/trac/jules/intertrac/wiki%3ACuratingARelease>`_
+
+
+Mule and Shumlib Releases
+-------------------------
+
+**Dependencies**
+All tickets affecting Shumlib or Mule should have been committed.
+
+`Mule and Shumlib Releases <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#ShumlibMulereleases>`_
+
+
+Main UM Release
+---------------
+
+**Dependencies**
+All UM Tickets, Test Release, Partner Testing, Jules Release
+
+:ref:`UM Main Release<um_main_release>`
+
+
+LFRic Apps Release
+------------------
+
+**Dependencies**
+All LFRic Tickets (Apps + Core), Jules Release
+
+:ref:`LFRic Apps Release<lfric_apps_release>`
+
+
+Post Release Tasks
+==================
+
+Release Notes
+-------------
+
+**Dependencies**
+Most of this can be done pre-release but some details of revision numbers will be dependent on the main release being done.
+
+`Release Notes <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#ReleaseNotes>`_
+
+
+Upgrading Standalone Suites
+---------------------------
+
+**Dependencies**
+UM Release (for UM suites), Apps Release (for Apps suites)
+
+`Upgrading Standalone Suites <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#UpgradingStandaloneSuites>`_
+
+
+Standard Jobs Page
+------------------
+
+**Dependencies**
+UM Release
+
+`Standard Jobs Page <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#FinalizeTheStandardJobspage>`_
+
+
+Code and Stash Browsers
+-----------------------
+
+**Dependencies**
+UM Release
+
+`Code and Stash Browsers <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#InstallCodeandStashbrowsers>`_
+
+
+UMDP Release
+------------
+
+**Dependencies**
+UM Release, Standard Suites Upgrade
+
+`UMDP Release <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#UMDPrelease>`_
+
+
+Update Wikis, Working Practices, Create Bit Comp Table
+------------------------------------------------------
+
+**Dependencies**
+UM Release
+
+`Wikis Update <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Updatewikisworkingpracticesandcreatebitcomptable>`_
+
+
+Review Shared Account Permissions
+---------------------------------
+
+**Dependencies**
+None
+
+`Shared Account Permissions <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Reviewandupdatetrunkandsharedaccountpermissions>`_
+
+
+Creating an Interim Release
+---------------------------
+
+`Creating an Interim Release <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Creatinganinterimrelease>`_
+
+
+Installing New Prebuilds
+------------------------
+
+`Installing New Prebuilds <https://code.metoffice.gov.uk/trac/um/wiki/CuratingARelease#Installingnewprebuilds>`_

--- a/source/Reviewers/curaterelease.rst
+++ b/source/Reviewers/curaterelease.rst
@@ -8,6 +8,30 @@ Curating a Release
     releases/um_main_release
     releases/lfric_apps_release
 
+.. _reference-tagging:
+
+Tagging FCM Trunks
+------------------
+
+Tagging fcm trunks with new release keywords is done in lots of places throughout these instructions. This section is a guide for doing this, using the UM as an example.
+
+The keywords need to be added to the base directory of the project, i.e. in the directory that contains trunk and branches.
+
+.. code-block::
+
+    # Note the -q means quiet checkout, nothing is printed to std out. The -N means
+    # only the top level directory is extracted, otherwise it would extract the
+    # entire repository (and take many hours!)
+    # The 'fcm log' command gives you the most recent log message for the
+    # respective trunk, and more importantly, the revision number.
+
+    fcm co -q -N fcm:um.x um
+    fcm log -l1 fcm:um.x/trunk
+    cd um
+    fcm pe fcm:revision .
+
+In the editor that comes up (you may need to specify the editor using ``--editor-cmd vi``) add the new keyword, e.g. ``vn11.5 = 810`` (noting the format may change away from the UM). Once completed save the changes and close the editor. Finally commit the change, ``fcm ci``.
+
 
 Release Ticket
 --------------

--- a/source/Reviewers/curaterelease.rst
+++ b/source/Reviewers/curaterelease.rst
@@ -104,7 +104,7 @@ Jules Release
 **Dependencies**
 Partner Testing, All Jules tickets committed
 
-`Jules Release <https://code.metoffice.gov.uk/trac/jules/intertrac/wiki%3ACuratingARelease>`_
+`Jules Release <https://code.metoffice.gov.uk/trac/jules/wiki/CuratingARelease>`_
 
 
 Mule and Shumlib Releases

--- a/source/Reviewers/releases/lfric_apps_release.rst
+++ b/source/Reviewers/releases/lfric_apps_release.rst
@@ -38,10 +38,20 @@ LFRic Release
   * Add a ``version_ab_xy.py`` upgrade file - a copy of the versions.py file
   * Reset the ``versions.py`` file with no upgrade macros
 
-* Run the test suite - make sure ``dependencies.sh`` is pointing at the core working copy
-* Reset the ``dependencies.sh``
-* LFRic Core should be ``coreX.Y``
-* All others should be ``umC.D``
-* Get the tickets reviewed and committed
-* Once the core ticket is committed ask CCD to tag core with ``coreX.Y=revision`` before committing apps
-* Tag the LFRic Apps Trunk ``vnX.Y=revision``
+* Run the test suites
+
+  * ``rose stem --group=all`` for both Apps and Core.
+  * Make sure ``dependencies.sh`` is pointing at the core working copy
+
+* Once testing is complete, reset the ``dependencies.sh``
+
+  * LFRic Core should be ``coreX.Y``
+  * All others should be ``umC.D``
+
+* Get the tickets reviewed and committed:
+
+  * Commit LFRic Core
+  * Ask CCD to :ref:`tag <reference-tagging>` core with ``coreX.Y=revision``
+  * Commit LFRic Apps
+
+* :ref:`Tag <reference-tagging>` the LFRic Apps Trunk ``vnX.Y=revision``

--- a/source/Reviewers/releases/lfric_apps_release.rst
+++ b/source/Reviewers/releases/lfric_apps_release.rst
@@ -1,0 +1,47 @@
+.. _lfric_apps_release:
+
+LFRic Apps Release
+==================
+
+LFRic Inputs KGO Install
+------------------------
+
+* This can be done at any point once all tickets that change lfricinputs kgo have been committed.
+* It's easiest to use the umtest nightly testing for this and will save having to run the suite twice.
+* Alternatively, run ``rose stem --group=lfricinputs`` and wait for this to finish - all jobs should pass.
+* Install the kgo by running ``$UMDIR/SimSys_Scripts/kgo_updates/meto_update_kgo.sh --new-release``
+
+  * The script will ask for a working copy path - this can be any lfric apps working copy as it will not be modified.
+  * The version number and ticket number are not required, although an entry is required.
+  * The kgo install directory must be updated to vnX.Y
+
+
+LFRic Release
+-------------
+
+* Create a ticket and branch in each of LFRic Apps and Core. Check both of these out.
+* Move into the lfric apps working copy
+* Run the release script, ``$UMDIR/SimSys_Scripts/lfric_macros/release_lfric.py -o A.B -v X.Y -t TTTT -c /path/to/core``
+
+  * ``A.B`` - the previous version
+  * ``X.Y`` - the new version
+  * ``TTTT`` - the apps release ticket number
+  * ``/path/to/core`` - path to the lfric core working copy
+
+* Check the output looks sensible. It should:
+
+  * Update the version number
+  * Revert any changes to ``rose-stem/site/meto/variables_*.cylc``
+  * Copy the ``HEAD`` metadata to ``vnX.Y``
+  * Add a blank upgrade macro to all ``versions.py`` files
+  * Apply the upgrade macro - rose apps should be updated to the new version
+  * Add a ``version_ab_xy.py`` upgrade file - a copy of the versions.py file
+  * Reset the ``versions.py`` file with no upgrade macros
+
+* Run the test suite - make sure ``dependencies.sh`` is pointing at the core working copy
+* Reset the ``dependencies.sh``
+* LFRic Core should be ``coreX.Y``
+* All others should be ``umC.D``
+* Get the tickets reviewed and committed
+* Once the core ticket is committed ask CCD to tag core with ``coreX.Y=revision`` before committing apps
+* Tag the LFRic Apps Trunk ``vnX.Y=revision``

--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -182,8 +182,8 @@ Preparing to Test
   .. code-block::
 
     fcm export --force fcm:um.x_tr/rose-stem/site/meto/variables.cylc rose-stem/site/meto/
-    fcm export --force fcm:um.x_tr/rose-stem/site/meto/variables_azspice.rc rose-stem/site/meto/
-    fcm export --force fcm:um.x_tr/rose-stem/site/meto/variables_ex1a.rc rose-stem/site/meto/
+    fcm export --force fcm:um.x_tr/rose-stem/site/meto/variables_azspice.cylc rose-stem/site/meto/
+    fcm export --force fcm:um.x_tr/rose-stem/site/meto/variables_ex1a.cylc rose-stem/site/meto/
 
   * Current KGO files will have the older UM version in the fixed length header and lookups. In order for the rose-ana tasks that use mule-cumf to not give false rose-ana failures we must temporarily ignore the model version. There is some logic in the UM rose stem suite to enable this. Open your ``~/.metomi/rose.conf`` file, on **all** platforms, and add the following lines to the rose-ana section, making sure that bypass-version-check is true:
 
@@ -227,7 +227,7 @@ The ``meto_update_kgo.sh`` script is stored in SimSys_Scripts. As yourself, navi
 
 * The script will install the new kgo on every platform in order azspice->ex1a. Once these are finished installing it will rsync to the EXCD. To install the entire kgo database will take some time.
 
-Once you believe you have installed the KGO you should fcm revert the changes you made to the variables.rc files to reset the KGO variables, ``fcm revert rose-stem/site/meto/variables*``
+Once you believe you have installed the KGO you should fcm revert the changes you made to the variables*.cylc files to reset the KGO variables, ``fcm revert rose-stem/site/meto/variables*``
 
 The test suite should now be rerun to confirm the kgo has been installed properly. As we can't restart Cylc8 rose-stem suites, the entire thing needs to be rerun. We're just checking that the kgo has been installed, so it's probably unnecessary to wait for the entire thing - instead just ensure a reasonable range of rose-ana tasks have passed.
 

--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -137,11 +137,13 @@ A new keyword will need to be created and copied into the rose-stem/rose-suite.c
 
 * Make sure the prebuilds are set to ``true`` in the ``site/meto/variables.cylc`` by checking the line, ``{% do SITE_VARS.update({"PREBUILDS" : true}) %}``
 * Check rose-stem/rose-suite.conf?
+
   * Are the UM, JULES, SOCRATES, CASIM and UKCA versions correct? These should be the keywords setup earlier.
   * Is housekeeping ``true``?
   * Are the KGO versions correct in the ``variables.cylc`` file for each site?
   * Does the minimum version of Rose/Cylc need to be increased? (Do any rose-ana changes require new functionality?)
   * Do any of the apps or parts of the suites reference ``$UMDIR`` - they shouldn't (the correct thing to do is to reference ``$UM_INSTALL_DIR``).
+
 * ``grep`` for any instances of the old version keyword(s). Fix as required and add any corrections to the instructions on this page too.
 
 Commit any changes resulting from these final checks.

--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -30,29 +30,18 @@ Create and check out both a head of trunk UM branch and a head of trunk UM meta 
     fcm co fcm:um_meta.x_br/dev/username/r12345_vn11.5_meta_release
 
 
-Tagging Trunks
---------------
+Tagging Feeder Trunks
+---------------------
 
-Tag the head of the ​CASIM, ​SOCRATES, ​Shumlib, JULES and ​UKCA with keywords for the new UM version if they do not already exist. The keywords need to be added to the base directory of the project, i.e. in the directory that contains trunk and branches. Here's an example of how to add a new keyword:
+Tag the head of the feeder repositories with keywords for the new UM version if they do not already exist.
 
-.. code-block::
+* ``fcm:casim.x``
+* ``fcm:jules.x``
+* ``fcm:shumlib.x``
+* ``fcm:socrates.x``
+* ``fcm:ukca.x``
 
-    # Note the -q means quiet checkout, nothing is printed to std out. The -N means
-    # only the top level directory is extracted, otherwise it would extract the
-    # entire repository (and take many hours!)
-    # The 'fcm log' command gives you the most recent log message for the
-    # respective trunk, and more importantly, the revision number.
-
-    fcm co -q -N fcm:socrates.x socrates
-    fcm log -l1 fcm:socrates.x/trunk
-    cd socrates
-    fcm pe fcm:revision .
-
-In the editor that comes up (you may need to specify the editor using --editor-cmd iuseemacs) add the new keyword, e.g. um11.5 = 810. Once completed save the changes and close the editor. Finally commit the change, ``fcm ci``.
-
-Repeat for ``fcm:shumlib.x``, ``fcm:ukca.x``, ``fcm:jules.x`` and ``fcm:casim.x``.
-
-Send an email and copy in all the repository owners (CASIM, Socrates, Shumlib, UKCA, JULES), to let them know that the the head of the trunk has been tagged.
+Send an email to all repository owners to let them know that the the head of the trunk has been tagged.
 
 .. note::
 
@@ -64,7 +53,7 @@ Apply Code Styling
 
 * Switch to the UM branch
 * Set export RUNFULL=1 then run ./admin/code_styling/apply_styling
-* If any files have changed, check nothing has gone wrong with a quick compile rose stem --group=fcm_make_ex1a_gnu_um_rigorous_omp -n um_release_check_styling
+* If any files have changed, check nothing has gone wrong with a quick compile ``rose stem --group=fcm_make_ex1a_gnu_um_rigorous_omp``
 * Commit any changes
 
 
@@ -75,7 +64,9 @@ The JULES release must be completed first and all jules-shared metadata changes 
 
 * First switch to the UM branch.
 * Check that the metadata meet the Rose standards. Do this before running release_new_version, so that any metadata errors are fixed before the new vnX.Y metadata directories are created, otherwise you'll have to check both vnX.Y and HEAD. Run ``rose config-dump -C rose-meta``.
-* Run ``fcm diff`` on HEAD. Are the changes sensible? They often just involve moving sections of meta-data to be in the correct alphabetical order. However, `UM:#1824 <https://code.metoffice.gov.uk/trac/um/ticket/1824>`_ added comments for some additional triggers ([43853]) to circumvent a ​bug in Rose. Running config-dump will move the location of these comments to the bottom of the that item's metadata. Check for any moved references to "issue 2107" (there should be 4 of them) and put them back in the right places by hand, by referring to an unaltered copy of the trunk.
+
+  * Run ``fcm diff`` on HEAD. Are the changes sensible? They often just involve moving sections of meta-data to be in the correct alphabetical order. However, `UM:#1824 <https://code.metoffice.gov.uk/trac/um/ticket/1824>`_ added comments for some additional triggers ([43853]) to circumvent a ​bug in Rose. Running config-dump will move the location of these comments to the bottom of the that item's metadata. Check for any moved references to "issue 2107" (there should be 4 of them) and put them back in the right places by hand, by referring to an unaltered copy of the trunk.
+
 * Check rose-stem meets the Rose standards: run ``rose config-dump -C rose-stem/app``. The version upgrade macro should have reformatted all the atmos and fcm-make apps, so they should be correct. Are there any other changes (e.g. to rose-ana apps)? Are they understood? Commit them to the branch or discuss with the team as appropriate.
 * Commit all changes before moving onto the next section
 
@@ -246,7 +237,7 @@ Notes for Reviewer:
 * In ``rose-stem/site/meto/variables``, ensure the ``PREBUILDS`` variable near the top is set to true.
 * Once happy, commit both the meta and main branches, and return the ticket to the developer.
 
-Now tag the trunk with the ``vnX.Y = RRR`` tag, following the process described above.
+Now :ref:`tag <reference-tagging>` the trunk with the ``vnX.Y = RRR`` tag.
 
 **Now make sure to revert changes to ``~/.metomi/fcm/keyword.cfg`` on all platforms**
 
@@ -296,13 +287,16 @@ Finally, rerun the install for the EXZ,
 
 The release is now installed and can be announced.
 
+Make Release Prebuilds
+----------------------
+
 Now it is time to install the prebuilds.
 
 .. important::
 
     Use Cylc 7 (``export CYLC_VERSION=7``) to install the prebuilds. It is important to set the source to the UM fcm mirror in the commands below, and use the config option to point at the rose-stem directory. If this wasn't done, prebuild availability would depend on the host machine you are currently on being available. rose-stem in cylc8 doesn't support this, hence using cylc7.
 
-    A fix for this will likely become available with either the move to git. The timescales for that are shorter than for removing Cylc7.
+    A fix for this will likely become available with the move to git. The timescales for that are shorter than for removing Cylc7.
 
 First install the prebuilds on Azure Spice and EXAB,
 
@@ -311,14 +305,14 @@ First install the prebuilds on Azure Spice and EXAB,
     export CYLC_VERSION=7
     rose stem --group=prebuilds --source=fcm:um.xm_tr@vnX.Y --name=vnX.Y_prebuilds --config=./rose-stem -S MAKE_PREBUILDS=true -S USE_EXAB=true
 
-And then on the EXCD - make sure to **not** use ``--new`` in this command or the previous lot will have been overwritten.
+And then on the EXCD - make sure to **not** use ``--new`` in this command or the previous set will have been overwritten.
 
 .. code-block::
 
     export CYLC_VERSION=7
     rose stem --group=ex1a_fcm_make,ex1a_fcm_make_portio2b --source=fcm:um.xm_tr@vnX.Y --name=vnX.Y_prebuilds --config=./rose-stem -S MAKE_PREBUILDS=true -S USE_EXCD=true
 
-And finally on the EXZ - make sure to **not** use ``--new`` in this command or the previous lot will have been overwritten.
+And finally on the EXZ - make sure to **not** use ``--new`` in this command or the previous set will have been overwritten.
 
 .. code-block::
 

--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -1,0 +1,312 @@
+.. _um_main_release:
+
+UM Main Release
+===============
+
+Create a ticket and Create Branches
+-----------------------------------
+
+To document the process create a ticket and put a link to it on the release curation ticket. You may wish to include links to the UM and UM metadata branches required and a wiki page for the reviews.
+
+.. code-block::
+
+    Documents the 'Build and install the <main/test> UM release'
+
+    NOTES: Any changes required that are not a direct instruction from this section of the guide.
+
+    '''Branch :''' [log:main/branches/dev/branch_path_n_name dev/branch_path_n_name]
+    '''Meta Branch :''' [log:meta/branches/dev/branch_path_n_name dev/branch_path_n_name]
+    '''[wiki:ticket/ticket_no/SciTechReview SciTech Review]'''
+    '''[wiki:ticket/ticket_no/CodeSystemReview Code/System Review]'''
+
+
+Create and check out both a head of trunk UM branch and a head of trunk UM meta branch. Then update the ticket description.
+
+.. code-block::
+
+    fcm bc -k ticket_no vn11.5_um_release fcm:um.x_tr
+    fcm co fcm:um.x_br/dev/username/r12345_vn11.5_um_release
+    fcm bc -k ticket_no vn11.5_meta_release fcm:um_meta.x_tr
+    fcm co fcm:um_meta.x_br/dev/username/r12345_vn11.5_meta_release
+
+
+Tagging Trunks
+--------------
+
+Tag the head of the ​CASIM, ​SOCRATES, ​Shumlib, JULES and ​UKCA with keywords for the new UM version if they do not already exist. The keywords need to be added to the base directory of the project, i.e. in the directory that contains trunk and branches. Here's an example of how to add a new keyword:
+
+.. code-block::
+
+    # Note the -q means quiet checkout, nothing is printed to std out. The -N means
+    # only the top level directory is extracted, otherwise it would extract the
+    # entire repository (and take many hours!)
+    # The 'fcm log' command gives you the most recent log message for the
+    # respective trunk, and more importantly, the revision number.
+
+    fcm co -q -N fcm:socrates.x socrates
+    fcm log -l1 fcm:socrates.x/trunk
+    cd socrates
+    fcm pe fcm:revision .
+
+In the editor that comes up (you may need to specify the editor using --editor-cmd iuseemacs) add the new keyword, e.g. um11.5 = 810. Once completed save the changes and close the editor. Finally commit the change, ``fcm ci``.
+
+Repeat for ``fcm:shumlib.x``, ``fcm:ukca.x``, ``fcm:jules.x`` and ``fcm:casim.x``.
+
+Send an email and copy in all the repository owners (CASIM, Socrates, Shumlib, UKCA, JULES), to let them know that the the head of the trunk has been tagged.
+
+.. note::
+
+    Jules should already have been done by the Jules release, but this is worth checking.
+
+
+Apply Code Styling
+------------------
+
+* Switch to the UM branch
+* Set export RUNFULL=1 then run ./admin/code_styling/apply_styling
+* If any files have changed, check nothing has gone wrong with a quick compile rose stem --group=fcm_make_ex1a_gnu_um_rigorous_omp -n um_release_check_styling
+* Commit any changes
+
+
+Checking Metadata and Rose Apps
+-------------------------------
+
+The JULES release must be completed first and all jules-shared metadata changes from the JULES repository must be centrally installed before progressing.
+
+* First switch to the UM branch.
+* Check that the metadata meet the Rose standards. Do this before running release_new_version, so that any metadata errors are fixed before the new vnX.Y metadata directories are created, otherwise you'll have to check both vnX.Y and HEAD. Run ``rose config-dump -C rose-meta``.
+* Run ``fcm diff`` on HEAD. Are the changes sensible? They often just involve moving sections of meta-data to be in the correct alphabetical order. However, `UM:#1824 <https://code.metoffice.gov.uk/trac/um/ticket/1824>`_ added comments for some additional triggers ([43853]) to circumvent a ​bug in Rose. Running config-dump will move the location of these comments to the bottom of the that item's metadata. Check for any moved references to "issue 2107" (there should be 4 of them) and put them back in the right places by hand, by referring to an unaltered copy of the trunk.
+* Check rose-stem meets the Rose standards: run ``rose config-dump -C rose-stem/app``. The version upgrade macro should have reformatted all the atmos and fcm-make apps, so they should be correct. Are there any other changes (e.g. to rose-ana apps)? Are they understood? Commit them to the branch or discuss with the team as appropriate.
+* Commit all changes before moving onto the next section
+
+
+Running the Release Script
+--------------------------
+
+Move into the rose-stem directory in the UM working copy where the release new version script will be run from. The syntax is,
+
+.. code-block::
+
+    ../admin/rose-stem/release_new_version.py -c <previous version> -n <new version> -j <new *JULES* version>
+    eg. ../admin/rose-stem/release_new_version.py -c 13.4 -n 13.5 -j 7.5
+
+* Open a new terminal and inspect that the version number update macro added by the script is correct, and that the tXXXX template macro has been deleted appropriately.
+
+  * This has caused problems before see `this edge case <https://code.metoffice.gov.uk/trac/um/wiki/ticket/2437/SciTechReview>`. The upgrade macro should fail to execute if the macro chain is incorrect, as it won't be able to upgrade an app to the new version - this is likely this edge case.
+
+
+Copying the metadata and upgrade macros to the um_meta branch
+-------------------------------------------------------------
+
+The next step is to move the macros and metadata into the meta branch. The metadata will have been created already by the release script.
+Below shows an example of the commands run to move from 11.4 to 11.5, from the top directory of the working copy of the UM branch,
+
+.. code-block::
+
+    version="version114_115.py"
+    vn="vn11.5"
+    path="/path/to/meta/working_copy"
+
+    fcm mv rose-meta/um-atmos/$version $path/um-atmos/$version
+    fcm mv rose-meta/um-fcm-make/$version $path/um-fcm-make/$version
+    fcm mv rose-meta/um-createbc/$version $path/um-createbc/$version
+
+    fcm mv rose-meta/um-atmos/$vn $path/um-atmos/$vn
+    fcm mv rose-meta/um-fcm-make/$vn $path/um-fcm-make/$vn
+    fcm mv rose-meta/um-createbc/$vn $path/um-createbc/$vn
+
+Note: there is no need to move um-crmstyle as it only contains HEAD metadata.
+
+Manually add a line to each of the um-atmos/versions.py, um-fcm-make/versions.py and um-createbc/versions.py files in the meta branch to import the newly copied versionXX_XY.py file.
+
+Commit the changes to both the UM and Meta branches.
+
+
+Final Checks
+------------
+
+**UM AUX Changes**
+
+If there are changes to the AUX trunk in this release, are we picking up the head of the AUX trunk (fcm:um_aux)?
+A new keyword will need to be created and copied into the rose-stem/rose-suite.conf file.
+
+.. code-block::
+
+    fcm co -q -N fcm:um_aux.x aux
+    fcm log -l1 fcm:um_aux.x/trunk
+    cd aux
+    fcm pe fcm:revision .
+    fcm commit
+
+.. warning::
+
+    Updating ``HOST_SOURCE_UM_AUX`` with the new keyword is NOT done automatically by release_new_version.py as it doesn't need to be done every release
+
+**Other Points**
+
+* Make sure the prebuilds are set to ``true`` in the ``site/meto/variables.cylc`` by checking the line, ``{% do SITE_VARS.update({"PREBUILDS" : true}) %}``
+* Check rose-stem/rose-suite.conf?
+  * Are the UM, JULES, SOCRATES, CASIM and UKCA versions correct? These should be the keywords setup earlier.
+  * Is housekeeping ``true``?
+  * Are the KGO versions correct in the ``variables.cylc`` file for each site?
+  * Does the minimum version of Rose/Cylc need to be increased? (Do any rose-ana changes require new functionality?)
+  * Do any of the apps or parts of the suites reference ``$UMDIR`` - they shouldn't (the correct thing to do is to reference ``$UM_INSTALL_DIR``).
+* ``grep`` for any instances of the old version keyword(s). Fix as required and add any corrections to the instructions on this page too.
+
+Commit any changes resulting from these final checks.
+
+
+Preparing to Test
+-----------------
+
+.. important::
+
+    When referring to **all** platforms below, this means Azure Spice, EXAB, EXCD
+
+
+* Check that a ``$UMDIR/standard_jobs/inputs/vnX.Y`` input data directory exists in UMDIR on **all** platforms - this should have been done as part of the test release.
+
+  * If not, rename the inputs directory ``$UMDIR/standard_jobs/inputs/vnX.Y`` to the new version number and be sure to symlink the previous version to it. Do this all on one line to minimise any glitches during the rename. This needs to be repeated on all platforms. i.e. to update from vn11.5 to vn11.6 one would run, ``mv vn11.5 vn11.6; ln -s vn11.6 vn11.5``.
+
+* Local keywords for the UM should be put in your ``~/.metomi/fcm/keyword.cfg`` file on **all** platforms (don't forget to remove them afterwards). The tag should correspond to the version you are releasing and the version number should be the revision of the trunk from which you branched. For example:
+
+  .. code-block::
+
+    revision[um.x:vn10.0]                    = 112
+    revision[um.xm:vn10.0]                   = 112
+
+* For the rose_ana tasks to pass new KGO also needs to be generated for the new version, since you are about to run the ``all`` group test anyway you should use this opportunity to produce a new set of KGO.
+
+  * KGO is installed using the scripts in SimSys_Scripts. In order for the script to work you must first change the KGO directories in the ``variables.cylc`` and platform-specific ``variables_PLATFORM.cylc`` files back to whichever versions were present before the ``release_new_version.py`` script was run - you can do this with a simple copy from the head of the trunk. Be careful to ensure this is only changing the KGO versions for each variable as expected. **DO NOT COMMIT this change - you will be reverting it later**.
+
+  .. code-block::
+
+    fcm export --force fcm:um.x_tr/rose-stem/site/meto/variables.cylc rose-stem/site/meto/
+    fcm export --force fcm:um.x_tr/rose-stem/site/meto/variables_azspice.rc rose-stem/site/meto/
+    fcm export --force fcm:um.x_tr/rose-stem/site/meto/variables_ex1a.rc rose-stem/site/meto/
+
+  * Current KGO files will have the older UM version in the fixed length header and lookups. In order for the rose-ana tasks that use mule-cumf to not give false rose-ana failures we must temporarily ignore the model version. There is some logic in the UM rose stem suite to enable this. Open your ``~/.metomi/rose.conf`` file, on **all** platforms, and add the following lines to the rose-ana section, making sure that bypass-version-check is true:
+
+  .. code-block::
+
+    [rose-ana]
+    bypass-version-check=.true.
+
+
+Testing and KGO Generation
+--------------------------
+
+As yourself, and in the working copy of the UM branch run rose stem, be sure not to forget the source argument to the UM metadata branch,
+
+.. code-block::
+
+    rose stem --task=all -S PREBUILDS=false -S HOUSEKEEPING=false -S USE_EXAB=true --source=. --source=/path/to/metadata/working_copy
+    cylc play <name-of-suite>
+
+Before continuing the next step you should make sure the suite has run as expected. All tests should pass apart from any tasks that output netcdf (these have _nc in the tasks name) and the SCM tasks. Both of these encode the UM version and use a direct comparison, it is not as simple to exclude UM version from the comparison as we did with tests that use mule-cumf.
+
+.. tip::
+
+    Check the test results by running something like
+
+    .. code-block::
+
+        find ~cylc-run/<suite name>/runN/log/job -path "*rose_ana*" -type f -name job.status | xargs grep -l CYLC_JOB_EXIT=ERR | grep -vE "(scm|netcdf)"
+
+The ``meto_update_kgo.sh`` script is stored in SimSys_Scripts. As yourself, navigate to ``$UMDIR/SimSys_Scripts/kgo_updates`` directory and run ``./meto_update_kgo.sh --new-release`` and follow its instructions.
+
+* First it will ask for all platforms run on, ``azspice ex1a``
+* It will ask which Host Zone the tests ran on - we specified EXAB so choose that (Host Zone 1).
+* You will need to supply the username and suitename of the suite you ran above. This will need to include the ``runX`` directory.
+* The version number should be the new version.
+* The ticket number won't be used but can be entered as the ticket associated with the release.
+* When asked how the new kgo directory should be named overwrite the default with the name ``vnX.Y`` where this is the new version number.
+* It will show you the settings to double check before you continue.
+
+  * Pay particular attention to the preview of the list of commands the script will present you with to ensure it has accounted for all expected KGO files.
+
+* The script will install the new kgo on every platform in order azspice->ex1a. Once these are finished installing it will rsync to the EXCD. To install the entire kgo database will take some time.
+
+Once you believe you have installed the KGO you should fcm revert the changes you made to the variables.rc files to reset the KGO variables, ``fcm revert rose-stem/site/meto/variables*``
+
+The test suite should now be rerun to confirm the kgo has been installed properly. As we can't restart Cylc8 rose-stem suites, the entire thing needs to be rerun. We're just checking that the kgo has been installed, so it's probably unnecessary to wait for the entire thing - instead just ensure a reasonable range of rose-ana tasks have passed.
+
+.. tip::
+
+    Has the ability to reload the test suite been enabled yet? If so ``cylc vr`` can likely be used to restart the original suite. These instructions also need updating!
+
+
+Review and Commit
+-----------------
+
+Ensure all changes are committed to both branches and then pass along for a review to someone in the team.
+
+Notes for Reviewer:
+
+* In ``rose-stem/site/meto/variables``, ensure the ``PREBUILDS`` variable near the top is set to true.
+* Once happy, commit both the meta and main branches, and return the ticket to the developer.
+
+Now tag the trunk with the ``vnX.Y = RRR`` tag, following the process described above.
+
+**Now make sure to revert changes to ``~/.metomi/fcm/keyword.cfg`` on all platforms**
+
+
+Install the Release
+-------------------
+
+The main installation of ctldata, utilities and prebuilds can now take place. This all takes place as the ``umadmin`` account so log in to that now.
+
+Delete any remaining temporary vnX.Y keywords for umadmin/umtest, on **all** platforms. Check all keyword.cfg files, and do both accounts now. They could be left over from the earlier test build, even if you didn't set them.
+
+Check out the UM trunk into a working copy. umadmin can only check out from the mirror.
+
+.. code-block::
+
+    fcm co fcm:um.xm_tr@vnX.Y umX.Y_install
+    cd umX.Y_install
+
+First check that the upgrade has gone successfully and the new install will appear in the correct place. Do this by running,
+
+.. code-block::
+
+    rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXAB=true
+    cylc play <name-of-suite>
+
+and check that ``~umadmin/cylc_run/<working_copy_name>/runN/share/vnX.Y`` exists and is the new version number. If that has worked, change the CENTRALL_INSTALL flag to true and rerun,
+
+.. code-block::
+
+    rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXAB=true
+    cylc play <name-of-suite>
+
+
+Finally, rerun the install for the 2nd host zone,
+
+.. code-block::
+
+    rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXCD=true
+    cylc play <name-of-suite>
+
+The release is now installed and can be announced.
+
+Now it is time to install the prebuilds.
+
+.. important::
+
+    Use Cylc 7 (``export CYLC_VERSION=7``) to install the prebuilds. It is important to set the source to the UM fcm mirror in the commands below, and use the config option to point at the rose-stem directory. If this wasn't done, prebuild availability would depend on the host machine you are currently on being available. rose-stem in cylc8 doesn't support this, hence using cylc7.
+
+    A fix for this will likely become available with either the move to git. The timescales for that are shorter than for removing Cylc7.
+
+First install the prebuilds on Azure Spice and EXAB,
+
+.. code-block::
+
+    export CYLC_VERSION=7
+    rose stem --group=prebuilds --source=fcm:um.xm_tr@vnX.Y --name=vnX.Y_prebuilds --config=./rose-stem -S MAKE_PREBUILDS=true -S USE_EXAB=true
+
+And then on the EXCD - make sure to **not** use ``--new`` in this command or the previous lot will have been overwritten.
+
+.. code-block::
+
+    export CYLC_VERSION=7
+    rose stem --group=ex1a_fcm_make,ex1a_fcm_make_portio2b --source=fcm:um.xm_tr@vnX.Y --name=vnX.Y_prebuilds --config=./rose-stem -S MAKE_PREBUILDS=true -S USE_EXCD=true

--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -92,7 +92,7 @@ Move into the rose-stem directory in the UM working copy where the release new v
 
 * Open a new terminal and inspect that the version number update macro added by the script is correct, and that the tXXXX template macro has been deleted appropriately.
 
-  * This has caused problems before see `this edge case <https://code.metoffice.gov.uk/trac/um/wiki/ticket/2437/SciTechReview>`. The upgrade macro should fail to execute if the macro chain is incorrect, as it won't be able to upgrade an app to the new version - this is likely this edge case.
+  * This has caused problems before see `this edge case <https://code.metoffice.gov.uk/trac/um/wiki/ticket/2437/SciTechReview>`_. The upgrade macro should fail to execute if the macro chain is incorrect, as it won't be able to upgrade an app to the new version - this is likely this edge case.
 
 
 Copying the metadata and upgrade macros to the um_meta branch

--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -33,7 +33,7 @@ Create and check out both a head of trunk UM branch and a head of trunk UM meta 
 Tagging Feeder Trunks
 ---------------------
 
-Tag the head of the feeder repositories with keywords for the new UM version if they do not already exist.
+* :ref:`Tag <reference-tagging>` the head of the feeder repositories with keywords for the new UM version if they do not already exist.
 
 * ``fcm:casim.x``
 * ``fcm:jules.x``
@@ -63,7 +63,7 @@ Checking Metadata and Rose Apps
 The JULES release must be completed first and all jules-shared metadata changes from the JULES repository must be centrally installed before progressing.
 
 * First switch to the UM branch.
-* Check that the metadata meets the Rose standards: run ``rose config-dump -C rose-meta``. Do this before running release_new_version, so that any metadata errors are fixed before the new vnX.Y metadata directories are created, otherwise you'll have to check both vnX.Y and HEAD. 
+* Check that the metadata meets the Rose standards: run ``rose config-dump -C rose-meta``. Do this before running release_new_version, so that any metadata errors are fixed before the new vnX.Y metadata directories are created, otherwise you'll have to check both vnX.Y and HEAD.
 
   * Run ``fcm diff`` on HEAD. Are the changes sensible? They often just involve moving sections of meta-data to be in the correct alphabetical order. However, `UM:#1824 <https://code.metoffice.gov.uk/trac/um/ticket/1824>`_ added comments for some additional triggers ([43853]) to circumvent a ​bug in Rose. Running config-dump will move the location of these comments to the bottom of the that item's metadata. Check for any moved references to "issue 2107" (there should be 4 of them) and put them back in the right places by hand, by referring to an unaltered copy of the trunk.
 

--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -52,7 +52,7 @@ Apply Code Styling
 ------------------
 
 * Switch to the UM branch
-* Set export RUNFULL=1 then run ./admin/code_styling/apply_styling
+* Set ``export RUNFULL=1`` then run ./admin/code_styling/apply_styling
 * If any files have changed, check nothing has gone wrong with a quick compile ``rose stem --group=fcm_make_ex1a_gnu_um_rigorous_omp``
 * Commit any changes
 
@@ -63,7 +63,7 @@ Checking Metadata and Rose Apps
 The JULES release must be completed first and all jules-shared metadata changes from the JULES repository must be centrally installed before progressing.
 
 * First switch to the UM branch.
-* Check that the metadata meet the Rose standards. Do this before running release_new_version, so that any metadata errors are fixed before the new vnX.Y metadata directories are created, otherwise you'll have to check both vnX.Y and HEAD. Run ``rose config-dump -C rose-meta``.
+* Check that the metadata meets the Rose standards: run ``rose config-dump -C rose-meta``. Do this before running release_new_version, so that any metadata errors are fixed before the new vnX.Y metadata directories are created, otherwise you'll have to check both vnX.Y and HEAD. 
 
   * Run ``fcm diff`` on HEAD. Are the changes sensible? They often just involve moving sections of meta-data to be in the correct alphabetical order. However, `UM:#1824 <https://code.metoffice.gov.uk/trac/um/ticket/1824>`_ added comments for some additional triggers ([43853]) to circumvent a ​bug in Rose. Running config-dump will move the location of these comments to the bottom of the that item's metadata. Check for any moved references to "issue 2107" (there should be 4 of them) and put them back in the right places by hand, by referring to an unaltered copy of the trunk.
 
@@ -249,7 +249,7 @@ The main installation of ctldata, utilities and prebuilds can now take place. Th
 
 Delete any remaining temporary vnX.Y keywords for umadmin/umtest, on **all** platforms. Check all keyword.cfg files, and do both accounts now. They could be left over from the earlier test build, even if you didn't set them.
 
-Check out the UM trunk into a working copy. umadmin can only check out from the mirror.
+Check out the UM trunk into a working copy. ``umadmin`` can only check out from the mirror.
 
 .. code-block::
 
@@ -267,7 +267,7 @@ and check that ``~umadmin/cylc_run/<working_copy_name>/runN/share/vnX.Y`` exists
 
 .. code-block::
 
-    rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXAB=true
+    rose stem --group=install rose-stem -S CENTRAL_INSTALL=true -S PREBUILDS=false -S USE_EXAB=true
     cylc play <name-of-suite>
 
 

--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -161,7 +161,7 @@ Preparing to Test
 
 .. important::
 
-    When referring to **all** platforms below, this means Azure Spice, EXAB, EXCD
+    When referring to **all** platforms below, this means Azure Spice, EXAB, EXCD, EXZ
 
 
 * Check that a ``$UMDIR/standard_jobs/inputs/vnX.Y`` input data directory exists in UMDIR on **all** platforms - this should have been done as part of the test release.
@@ -225,7 +225,7 @@ The ``meto_update_kgo.sh`` script is stored in SimSys_Scripts. As yourself, navi
 
   * Pay particular attention to the preview of the list of commands the script will present you with to ensure it has accounted for all expected KGO files.
 
-* The script will install the new kgo on every platform in order azspice->ex1a. Once these are finished installing it will rsync to the EXCD. To install the entire kgo database will take some time.
+* The script will install the new kgo on every platform in order azspice->ex1a. Once these are finished installing it will rsync to the EXCD and EXZ. To install the entire kgo database will take some time.
 
 Once you believe you have installed the KGO you should fcm revert the changes you made to the variables*.cylc files to reset the KGO variables, ``fcm revert rose-stem/site/meto/variables*``
 
@@ -280,11 +280,18 @@ and check that ``~umadmin/cylc_run/<working_copy_name>/runN/share/vnX.Y`` exists
     cylc play <name-of-suite>
 
 
-Finally, rerun the install for the 2nd host zone,
+Next, rerun the install for the 2nd host zone,
 
 .. code-block::
 
     rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXCD=true
+    cylc play <name-of-suite>
+
+Finally, rerun the install for the EXZ,
+
+.. code-block::
+
+    rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXZ=true
     cylc play <name-of-suite>
 
 The release is now installed and can be announced.
@@ -310,3 +317,10 @@ And then on the EXCD - make sure to **not** use ``--new`` in this command or the
 
     export CYLC_VERSION=7
     rose stem --group=ex1a_fcm_make,ex1a_fcm_make_portio2b --source=fcm:um.xm_tr@vnX.Y --name=vnX.Y_prebuilds --config=./rose-stem -S MAKE_PREBUILDS=true -S USE_EXCD=true
+
+And finally on the EXZ - make sure to **not** use ``--new`` in this command or the previous lot will have been overwritten.
+
+.. code-block::
+
+    export CYLC_VERSION=7
+    rose stem --group=ex1a_fcm_make,ex1a_fcm_make_portio2b --source=fcm:um.xm_tr@vnX.Y --name=vnX.Y_prebuilds --config=./rose-stem -S MAKE_PREBUILDS=true -S USE_EXZ=true

--- a/source/Reviewers/releases/um_test_release.rst
+++ b/source/Reviewers/releases/um_test_release.rst
@@ -64,7 +64,7 @@ As yourself, move into the rose-stem directory in the UM working copy where the 
 
   * This has caused problems before see `this edge case <https://code.metoffice.gov.uk/trac/um/wiki/ticket/2437/SciTechReview>`. The upgrade macro should fail to execute if the macro chain is incorrect, as it won't be able to upgrade an app to the new version - this is likely this edge case.
 
-* As there is no kgo installed for the new version we need to revert the changes to ``rose-stem/site/meto/variables_*.cylc`` as well as the ``BASE`` variable at the bottom of ``rose-stem/site/meto/variables.cylc``.
+* As there is no kgo installed for the new version revert the changes to ``rose-stem/site/meto/variables_*.cylc`` as well as the ``BASE`` variable at the bottom of ``rose-stem/site/meto/variables.cylc``.
 
 Copying the metadata and upgrade macros to the um_meta branch
 -------------------------------------------------------------
@@ -116,7 +116,7 @@ and check that ``~umadmin/cylc_run/<working_copy_name>/runN/share/vnX.Y`` exists
 
 .. code-block::
 
-    rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXAB=true
+    rose stem --group=install rose-stem -S CENTRAL_INSTALL=true -S PREBUILDS=false -S USE_EXAB=true
     cylc play <name-of-suite>
 
 Now install the prebuilds by running,

--- a/source/Reviewers/releases/um_test_release.rst
+++ b/source/Reviewers/releases/um_test_release.rst
@@ -13,6 +13,7 @@ Preparing Test Release Branches and Keyword Files
 -------------------------------------------------
 
 This will involve switching between your own and the umadmin account on Azure Spice and EXAB.
+
 * As yourself, create a UM ticket for the test release, marked 'Not for Builds'.
 * As yourself, create and check out a UM branch at the head of the trunk (or whichever revision of the trunk you wish to do a test release with).
 * As yourself, create and check out a head of trunk meta branch (``fcm:um_meta.x_tr@head``).

--- a/source/Reviewers/releases/um_test_release.rst
+++ b/source/Reviewers/releases/um_test_release.rst
@@ -1,0 +1,180 @@
+.. _um_test_release:
+
+UM Test Release
+===============
+
+.. important::
+
+    When referring to **all** platforms below, this means Azure Spice, EXAB, EXCD
+
+    Some of the test release only needs to be run on 1 HPC Host Zone - the instructions for this assume EXAB, but EXCD can be used instead. Other parts of the test release set up files for the main release - this needs to be done on both EXAB and EXCD.
+
+Preparing Test Release Branches and Keyword Files
+-------------------------------------------------
+
+This will involve switching between your own and the umadmin account on Azure Spice, EXAB and EXCD.
+* As yourself, create a UM ticket for the test release, marked 'Not for Builds'.
+* As yourself, create and check out a UM branch at the head of the trunk (or whichever revision of the trunk you wish to do a test release with).
+* As yourself, create and check out a head of trunk meta branch (``fcm:um_meta.x_tr@head``).
+* As umadin, setup the ``~/.metomi/fcm/keyword.cfg`` file on Azure Spice to specify custom keywords for the UM, ​JULES, ​SOCRATES, ​CASIM, ​Shumlib, ​UKCA and the mirrors of each of these named after the upcoming version and pointing to the current head of trunk revisions of each project. No keywords are needed for mule, moci or meta repositories.
+* The general format looks like this- substitute model version and revisions
+
+  * Remember to remove any existing hashtags/make sure these lines aren't commented out
+  * For the test release we also need to set the Jules vn keyword (last line). This needs to match the jules version that is passed to release_new_version script below.
+
+.. code-block::
+
+    revision[um.x:vn13.5]        = 123059
+    revision[jules.x:um13.5]     = 28020
+    revision[socrates.x:um13.5]  = 1563
+    revision[casim.x:um13.5]     = 10951
+    revision[shumlib.x:um13.5]   = 7324
+    revision[ukca.x:um13.5]      = 3196
+
+    revision[um.xm:vn13.5]       = 123059
+    revision[jules.xm:um13.5]    = 28020
+    revision[socrates.xm:um13.5] = 1563
+    revision[casim.xm:um13.5]    = 10951
+    revision[shumlib.xm:um13.5]  = 7324
+    revision[ukca.xm:um13.5]     = 3196
+
+    revision[jules.xm:vn7.5]     = 28020
+
+* As umadmin, scp this file to the EXAB, ``scp ~/.metomi/fcm/keyword.cfg login.exab.sc:.metomi/fcm/keyword.cfg``
+* As yourself, copy this file into your own homespace ready for testing later, ``cp ~umadmin/.metomi/fcm/keyword.cfg ~/.metomi/fcm/keyword.cfg``. Do this on Azure Spice and EXAB.
+* As yourself, add the following to ``~/.metomi/rose.conf`` on Azure Spice and EXAB. This prevents kgo failures due to the new version number when we test later. Again, do this on Azure Spice and EXAB.
+
+.. code-block::
+
+    [rose-ana]
+    bypass-version-check=.true.
+
+
+Running the Release Script
+--------------------------
+
+As yourself, move into the rose-stem directory in the UM working copy where the release new version script will be run from. The syntax is,
+
+.. code-block::
+
+    ../admin/rose-stem/release_new_version.py -c <previous version> -n <new version> -j <new *JULES* version>
+    eg. ../admin/rose-stem/release_new_version.py -c 13.4 -n 13.5 -j 7.5
+
+* Open a new terminal and inspect that the version number update macro added by the script is correct, and that the tXXXX template macro has been deleted appropriately.
+
+  * This has caused problems before see `this edge case <https://code.metoffice.gov.uk/trac/um/wiki/ticket/2437/SciTechReview>`. The upgrade macro should fail to execute if the macro chain is incorrect, as it won't be able to upgrade an app to the new version - this is likely this edge case.
+
+* As there is no kgo installed for the new version we need to revert the changes to ``rose-stem/site/meto/variables_*.cylc`` as well as the ``BASE`` variable at the bottom of ``rose-stem/site/meto/variables.cylc``.
+
+Copying the metadata and upgrade macros to the um_meta branch
+-------------------------------------------------------------
+
+As yourself, the next step is to move the macros and metadata into the meta branch. The metadata will have been created already by the release script.
+Below shows an example of the commands run to move from 11.4 to 11.5, from the top directory of the working copy of the UM branch,
+
+.. code-block::
+
+    version="version114_115.py"
+    vn="vn11.5"
+    path="/path/to/meta/working_copy"
+
+    fcm mv rose-meta/um-atmos/$version $path/um-atmos/$version
+    fcm mv rose-meta/um-fcm-make/$version $path/um-fcm-make/$version
+    fcm mv rose-meta/um-createbc/$version $path/um-createbc/$version
+
+    fcm mv rose-meta/um-atmos/$vn $path/um-atmos/$vn
+    fcm mv rose-meta/um-fcm-make/$vn $path/um-fcm-make/$vn
+    fcm mv rose-meta/um-createbc/$vn $path/um-createbc/$vn
+
+Note: there is no need to move um-crmstyle as it only contains HEAD metadata.
+
+Manually add a line to each of the um-atmos/versions.py, um-fcm-make/versions.py and um-createbc/versions.py files in the meta branch to import the newly copied versionXX_XY.py file.
+
+Commit the changes to both the UM and Meta branches.
+
+
+Installing Ctldata, Utilities and Prebuilds
+-------------------------------------------
+
+These steps are all done as umadmin
+
+Check out the UM trunk into a working copy. umadmin can only check out from the mirror - if immediately following the previous steps, ensure the mirror has updated.
+
+.. code-block::
+
+    fcm co fcm:um.xm_tr@vnX.Y umX.Y_install
+    cd umX.Y_install
+
+First check that the upgrade has gone successfully and the new install will appear in the correct place. Do this by running,
+
+.. code-block::
+
+    rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXAB=true
+    cylc play <name-of-suite>
+
+and check that ``~umadmin/cylc_run/<working_copy_name>/runN/share/vnX.Y`` exists and is the new version number. If that has worked, change the CENTRALL_INSTALL flag to true and rerun,
+
+.. code-block::
+
+    rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXAB=true
+    cylc play <name-of-suite>
+
+Now install the prebuilds by running,
+
+.. code-block::
+
+    rose stem --group=prebuilds -S MAKE_PREBUILDS=true --workflow-name=vnX.Y_prebuilds --no-run-name
+
+.. tip::
+
+    In the main release, we use cylc7 for the prebuild install as the Cylc8 rose-stem is missing a feature. As we are going to be removing these prebuilds shortly, the default Cylc8 is fine for the test release.
+
+Navigate to the input data directory on azure spice (``$UMDIR/standard_jobs/inputs``) and run the following command which copies the old directory to the new one, and then creates a new symlink. Replace 11.5 and 11.6 with the correct version numbers,
+
+.. code-block::
+
+    mv vn11.5 vn11.6 && ln -s vn11.6 vn11.5
+
+Repeat this step on **both** EXAB and EXCD.
+
+
+Test the Branch
+---------------
+
+These steps are done as yourself.
+In your UM branch working copy, ensure the ``PREBUILDS`` variable in ``rose-stem/site/meto/variables.cylc`` is set to true so we test the new prebuilds.
+Then run the entire test suite,
+
+.. code-block::
+
+    rose stem --group=all --source=. --source=/path/to/meta/working/copy
+    cylc play <name-of-suite>
+
+Before continuing the next step you should make sure the suite has run as expected. All tests should pass apart from any tasks that output netcdf (these have _nc in the tasks name) and the SCM tasks. Both of these encode the UM version and use a direct comparison, it is not as simple to exclude UM version from the comparison as we did with tests that use mule-cumf.
+
+.. tip::
+
+    Check the test results by running something like
+
+    .. code-block::
+
+        find ~cylc-run/<suite name>/runN/log/job -path "*rose_ana*" -type f -name job.status | xargs grep -l CYLC_JOB_EXIT=ERR | grep -vE "(scm|netcdf)
+
+
+Reset Keywords and Remove Prebuilds (Important!)
+------------------------------------------------
+
+As both yourself and umadmin,
+
+* Remove or comment out the custom keyword revisions from ``~/.metomi/fcm/keywords.cfg``
+* Remove or comment out the ``bypass-version-check`` in ``~/.metomi/rose.conf``
+
+  * Make sure to do this on **all** platforms
+  * Not doing so can result in some weird behaviour down the line
+
+* As umadmin, remove the installed release and prebuilds. Doing this now saves significant time during the actual release. These steps should only need doing on Azure Spice and EXAB.
+
+  * Delete the ``$UMDIR/vnX.Y`` directory
+  * On Azure Spice, run ``cylc clean --timeout=5000 vnX.Y_prebuilds``. Once this has finished, check the cylc-run directory that the suite has been removed. Do this on all of $HOME, $DATADIR, $SCRATCH on both Azure Spice and EXAB.
+
+The test release is now done!

--- a/source/Reviewers/releases/um_test_release.rst
+++ b/source/Reviewers/releases/um_test_release.rst
@@ -5,14 +5,14 @@ UM Test Release
 
 .. important::
 
-    When referring to **all** platforms below, this means Azure Spice, EXAB, EXCD
+    When referring to **all** platforms below, this means Azure Spice, EXAB, EXCD, EXZ
 
     Some of the test release only needs to be run on 1 HPC Host Zone - the instructions for this assume EXAB, but EXCD can be used instead. Other parts of the test release set up files for the main release - this needs to be done on both EXAB and EXCD.
 
 Preparing Test Release Branches and Keyword Files
 -------------------------------------------------
 
-This will involve switching between your own and the umadmin account on Azure Spice, EXAB and EXCD.
+This will involve switching between your own and the umadmin account on Azure Spice and EXAB.
 * As yourself, create a UM ticket for the test release, marked 'Not for Builds'.
 * As yourself, create and check out a UM branch at the head of the trunk (or whichever revision of the trunk you wish to do a test release with).
 * As yourself, create and check out a head of trunk meta branch (``fcm:um_meta.x_tr@head``).
@@ -135,7 +135,7 @@ Navigate to the input data directory on azure spice (``$UMDIR/standard_jobs/inpu
 
     mv vn11.5 vn11.6 && ln -s vn11.6 vn11.5
 
-Repeat this step on **both** EXAB and EXCD.
+Repeat this step on **all of** EXAB, EXCD and EXZ.
 
 
 Test the Branch


### PR DESCRIPTION
An initial copy of the release curation instructions from trac to github. Whether this is the right place for these docs to end up is open to debate, but it's a reasonable holding place for now. Links to the most old sections are provided, but UM test and main release as well as lfric_apps release docs are fully ported, and updated to give correct references to the platforms we now have. 