### PR TITLE
add Monsoon docs

### DIFF
--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -334,7 +334,7 @@ First, log into Monsoon as ``umadmin.mon`` and then check out the trunk at the n
 
 .. code-block::
 
-    fcm co fcm:um.x_tr@vnXX.Y
+    fcm co fcm:um.xm_tr@vnXX.Y
 
 Next, symlink the input data as was done for other platforms,
 

--- a/source/Reviewers/releases/um_main_release.rst
+++ b/source/Reviewers/releases/um_main_release.rst
@@ -261,14 +261,14 @@ First check that the upgrade has gone successfully and the new install will appe
 
 .. code-block::
 
-    rose stem --group=install rose-stem -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXAB=true
+    rose stem --group=install -S CENTRAL_INSTALL=false -S PREBUILDS=false -S USE_EXAB=true
     cylc play <name-of-suite>
 
 and check that ``~umadmin/cylc_run/<working_copy_name>/runN/share/vnX.Y`` exists and is the new version number. If that has worked, change the CENTRALL_INSTALL flag to true and rerun,
 
 .. code-block::
 
-    rose stem --group=install rose-stem -S CENTRAL_INSTALL=true -S PREBUILDS=false -S USE_EXAB=true
+    rose stem --group=install -S CENTRAL_INSTALL=true -S PREBUILDS=false -S USE_EXAB=true
     cylc play <name-of-suite>
 
 
@@ -276,14 +276,14 @@ Next, rerun the install for the 2nd host zone,
 
 .. code-block::
 
-    rose stem --group=ex1a_install rose-stem -S CENTRAL_INSTALL=true -S PREBUILDS=false -S USE_EXCD=true
+    rose stem --group=ex1a_install -S CENTRAL_INSTALL=true -S PREBUILDS=false -S USE_EXCD=true
     cylc play <name-of-suite>
 
 Finally, rerun the install for the EXZ,
 
 .. code-block::
 
-    rose stem --group=ex1a_install rose-stem -S CENTRAL_INSTALL=true -S PREBUILDS=false -S USE_EXZ=true
+    rose stem --group=ex1a_install -S CENTRAL_INSTALL=true -S PREBUILDS=false -S USE_EXZ=true
     cylc play <name-of-suite>
 
 The release is now installed and can be announced.
@@ -319,3 +319,51 @@ And finally on the EXZ - make sure to **not** use ``--new`` in this command or t
 
     export CYLC_VERSION=7
     rose stem --group=ex1a_fcm_make,ex1a_fcm_make_portio2b --source=fcm:um.xm_tr@vnX.Y --name=vnX.Y_prebuilds --config=./rose-stem -S MAKE_PREBUILDS=true -S USE_EXZ=true
+
+
+Monsoon Installation
+--------------------
+
+.. tip::
+
+    This section can be done in parallel with the previous one
+
+We also install the UM onto Monsoon - to do this you will need a Monsoon account with access to the ``umadmin.mon`` shared account.
+
+First, log into Monsoon as ``umadmin.mon`` and then check out the trunk at the new version just released.
+
+.. code-block::
+
+    fcm co fcm:um.x_tr@vnXX.Y
+
+Next, symlink the input data as was done for other platforms,
+
+.. code-block::
+
+    mv vn11.5 vn11.6; ln -s vn11.6 vn11.5
+
+Now run the central install group,
+
+.. code-block::
+
+    rose stem --group=ex1a_install -S CENTRAL_INSTALL=true -S PREBUILDS=false
+    cylc play <name-of-suite>
+
+Install prebuilds on Monsoon. Note the ``--no-run-name`` is required to force the install location to be consistent with other platforms.
+
+.. code-block::
+
+    rose stem --group=ex1a_fcm_make,ex1a_fcm_make_portio2b -S MAKE_PREBUILDS=true -n vnX.Y_prebuilds --no-run-name
+    cylc play <name-of-suite>
+
+Finally we need to install the kgo for the release. Do this by running the ``ex1a`` group. Once that is finished, run the kgo install script (sourced from the SimSys_Scripts repo).
+
+.. code-block::
+
+    rose stem --group=ex1a
+    cylc play <name-of-suite>
+    # Wait for tests to complete
+    python3 SimSys_Scripts/kgo_updates/kgo_update/kgo_update.py -N vnX.Y -P ex1a --new-release --non-interactive
+
+Check that the kgo has been installed in place correctly at ``$UMDIR/standard_jobs/kgo``.
+

--- a/source/Reviewers/releases/um_test_release.rst
+++ b/source/Reviewers/releases/um_test_release.rst
@@ -162,6 +162,12 @@ Before continuing the next step you should make sure the suite has run as expect
         find ~cylc-run/<suite name>/runN/log/job -path "*rose_ana*" -type f -name job.status | xargs grep -l CYLC_JOB_EXIT=ERR | grep -vE "(scm|netcdf)
 
 
+Test on Monsoon
+---------------
+
+It's also sensible to check now that nothing has broken on Monsoon. Do this by copying your keyword settings across to your account on there. Then check out the UM main and meta branches and run the test suite as you in the previous section except for the group which should now be ``ex1a``.
+
+
 Reset Keywords and Remove Prebuilds (Important!)
 ------------------------------------------------
 
@@ -170,7 +176,7 @@ As both yourself and umadmin,
 * Remove or comment out the custom keyword revisions from ``~/.metomi/fcm/keywords.cfg``
 * Remove or comment out the ``bypass-version-check`` in ``~/.metomi/rose.conf``
 
-  * Make sure to do this on **all** platforms
+  * Make sure to do this on **all** platforms (inlcuding Monsoon)
   * Not doing so can result in some weird behaviour down the line
 
 * As umadmin, remove the installed release and prebuilds. Doing this now saves significant time during the actual release. These steps should only need doing on Azure Spice and EXAB.

--- a/source/WorkingPractices/TestSuites/um.rst
+++ b/source/WorkingPractices/TestSuites/um.rst
@@ -89,3 +89,24 @@ and that you can specify more than one at once, e.g. ``--group=developer,jules,u
     The `standard jobs <https://code.metoffice.gov.uk/trac/um/wiki/StandardJobs>`_
     page for each release includes details of which of ``developer``,
     ``nightly`` and ``all`` a configuration is tested at.
+
+
+Monsoon
+-------
+
+As of UM vn13.9, the UM is able to run on Monsoon3, the latest version hosted by the Meto EX machines. To run on here, users should follow the process laid out in the Monsoon User Guide. This involves logging onto the ``cazccylc1`` server to launch jobs.
+
+The UM test suite is set up to run on Monsoon with Cylc 8 by running,
+
+.. code-block::
+
+    rose stem --group=ex1a
+    cylc play <name-of-suite>
+
+This will launch all ex1a jobs that are available to run on Monsoon.
+
+For running suites on Monsoon, a few environment variables must be set for the builds to complete:
+
+* ``EX_UMDIR_OVERRIDE`` - this needs to be set to ``/projects/metoff/umdir``
+* ``ECCODES_VERSION`` - this needs to be set to ``eccodes-2.34.0``
+


### PR DESCRIPTION
Add some basic notes for running on Monsoon in rose-stem and as a suite user. 
Add docs for installing the UM release on Monsoon.

Ideally we would link to the Monsoon user guide but this isn't published yet so I'll open an issue to do that once the guide is available.