### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish_wps.yml
+++ b/.github/workflows/publish_wps.yml
@@ -8,6 +8,9 @@ on:
     types: [opened,reopened,review_requested]
   workflow_dispatch:
 
+permissions:
+  contents: write
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/MetOffice/simulation-systems/security/code-scanning/1](https://github.com/MetOffice/simulation-systems/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Based on the actions performed in the workflow, the following permissions are needed:
- `contents: read` for reading repository contents.
- `contents: write` for committing and pushing changes to the `gh-pages` branch.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build-and-deploy`) to limit its scope.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
