### PR TITLE
Update LFRIc Apps release process 

### DIFF
--- a/source/Reviewers/releases/lfric_apps_release.rst
+++ b/source/Reviewers/releases/lfric_apps_release.rst
@@ -8,7 +8,7 @@ LFRic Inputs KGO Install
 
 * This can be done at any point once all tickets that change lfricinputs kgo have been committed.
 * It's easiest to use the umtest nightly testing for this and will save having to run the suite twice.
-* Alternatively, run ``rose stem --group=lfricinputs`` and wait for this to finish - all jobs should pass.
+* Alternatively, run ``rose stem --group=lfricinputs -S HOUSEKEEPING=false`` and wait for this to finish - all jobs should pass.
 * Install the kgo by running ``$UMDIR/SimSys_Scripts/kgo_updates/meto_update_kgo.sh --new-release``
 
   * The script will ask for a working copy path - this can be any lfric apps working copy as it will not be modified.
@@ -38,15 +38,24 @@ LFRic Release
   * Add a ``version_ab_xy.py`` upgrade file - a copy of the versions.py file
   * Reset the ``versions.py`` file with no upgrade macros
 
+* Tag other repositories and update dependencies.sh:
+
+  * :ref:`Tag <reference-tagging>` CASIM, JULES, SOCRATES and UKCA with ``appsX.Y=revision``
+  * In dependencies.sh:
+
+    * Make sure ``lfric_core_sources`` is pointing at the core working copy with ``lfric_core_rev`` blank
+    * Update ``*_rev`` for all other repositories to be ``appsX.Y`` with ``*_sources`` blank
+
+* Commit your changes to both Apps and Core branches.
+
 * Run the test suites
 
   * ``rose stem --group=all`` for both Apps and Core.
-  * Make sure ``dependencies.sh`` is pointing at the core working copy
 
-* Once testing is complete, reset the ``dependencies.sh``
+* Once testing is complete, update LFRic Core in ``dependencies.sh``
 
-  * LFRic Core should be ``coreX.Y``
-  * All others should be ``umC.D``
+  * ``lfric_core_rev`` should be ``coreX.Y``
+  * ``lfric_core_sources`` should be blank
 
 * Get the tickets reviewed and committed:
 


### PR DESCRIPTION
Updating the apps release process to include

* use of housekeeping=false for the lfricinputs KGO
* tagging of other repos
* reminder to commit before running testing