### PR TITLE
add note about resolving comments as dev

### DIFF
--- a/source/WorkingPractices/reviews.rst
+++ b/source/WorkingPractices/reviews.rst
@@ -38,7 +38,7 @@ Trivial tickets are an exception and do not require a SciTech review.
     provide that external viewpoint.
 
 .. tip::
-    The reviewer will likely leave comments all of which should be addressed by
+    The reviewer will likely leave comments, all of which should be addressed by
     the developer. The developer should **not** resolve these comments
     themselves, instead allowing the reviewer to resolve them when they are
     happy with the response.

--- a/source/WorkingPractices/reviews.rst
+++ b/source/WorkingPractices/reviews.rst
@@ -37,6 +37,12 @@ Trivial tickets are an exception and do not require a SciTech review.
     then another person should be brought in to finish the review process and
     provide that external viewpoint.
 
+.. tip::
+    The reviewer will likely leave comments all of which should be addressed by
+    the developer. The developer should **not** resolve these comments
+    themselves, instead allowing the reviewer to resolve them when they are
+    happy with the response.
+
 
 Preparing for Review
 --------------------


### PR DESCRIPTION
Add a tip box saying to not resolve comments as the developer.

Looking at that reviews page, it seems like most of it is in some form of box. Maybe we want to rewrite some of those into the text instead?