### PR TITLE
Add Momentum Contributor Licence Agreement (CLA) document

### DIFF
--- a/Momentum-CLA.md
+++ b/Momentum-CLA.md
@@ -1,0 +1,44 @@
+# Momentum Contributor Licence Agreement (CLA)
+
+To best ensure that the BSD licence of Momentum® code can be sustained, we
+request that contributors from outside the Met Office agree with the following
+terms when submitting code for inclusion in Momentum®.
+
+Contributor Licence Agreement and Certificate of Origin
+
+By making a contribution to this project, I certify that:
+
+1. The contribution was created in whole or in part by me and I have the right
+   to submit it, either on my behalf or on behalf of my employer, under the
+   terms and conditions as described by this file; or
+
+2. The contribution is based upon previous work that, to the best of my
+   knowledge, is covered under an appropriate licence and I have the right or
+   permission from the copyright owner under that licence to submit that work
+   with modifications, whether created in whole or in part by me, under the
+   terms and conditions as described by this file; or
+
+3. The contribution was provided directly to me by some other person who
+   certified (1) or (2) and I have not modified it.
+
+4. I understand and agree that this project and the contribution are public and
+   that a record of the contribution (including my name and email address) is
+   retained for the full term of the copyright and may be redistributed
+   consistent with this project or the licence(s) involved.
+
+5. I, or my employer, grant to the UK Met Office and all recipients of this
+   software a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+   irrevocable copyright licence to reproduce, modify, prepare derivative works
+   of, publicly display, publicly perform, sub-licence, and distribute this
+   contribution and such modifications and derivative works consistent with this
+   project or the licence(s) involved or other appropriate open source
+   licence(s) specified by the project and approved by the
+   [Open Source Initiative (OSI)](http://www.opensource.org/).
+
+6. If I become aware of anything that would make any of the above inaccurate, in
+   any way, I will let the UK Met Office know as soon as I become aware.
+
+7. The CLA requires that any contributed IP be transferred back to the Met
+   Office.
+
+8. To end this Agreement please contact enquiries@metoffice.gov.uk


### PR DESCRIPTION
**THIS IS NOW SUPERSEDED BY** https://github.com/MetOffice/Momentum/pull/1

This is the initial* version of the Momentum® Contributor Licence Agreement (CLA) document. The intention is for this to serve as the central location for the Momentum® CLA, with references from other repositories directing to this document.

* The contents are subject to minor change, but I am adding it now so that we can test automated agreement process via GitHub Action.

Attn: 
- @jcmt
- @MetOffice/ssdteam