### PR TITLE
Run build and deployment in a single job

### DIFF
--- a/.github/workflows/publish_wps.yaml
+++ b/.github/workflows/publish_wps.yaml
@@ -8,8 +8,6 @@ on:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
 
-timeout-minutes: 5
-
 permissions:
   contents: read
   pages: write
@@ -18,6 +16,7 @@ permissions:
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     env:
       PYTHON_VRSN: '3.12'
       VENV_PATH: '.venv'


### PR DESCRIPTION
Based on an offline discussion, I've tried to merge the sphinx documentation build and deployment in a single job so that the checks in PR does not show the skipped deployment step (should still be visible in Action log though).

Also, an attempt to run the post build steps only for upstream push because we don't want the deployment to happen on user space (currently prohibited via settings on upstream repository)