### PR TITLE
user.signingkey is .pub

### DIFF
--- a/source/WorkingPractices/gh_authorisation.rst
+++ b/source/WorkingPractices/gh_authorisation.rst
@@ -140,9 +140,9 @@ Then configure git locally at the command line:
     # This assumes a global configuration
     # Substitute `git config` for `git config --global` for by-repository configuration
     git config --global gpg.format ssh
-    # Noting that the </path/to/key> is to the private part, and must match
+    # Noting that the </path/to/key> is to the public (`.pub`) part, and must match
     # the Github registered public key and the allowed-signers key.
-    git config --global user.signingkey </path/to/key>
+    git config --global user.signingkey </path/to/key>.pub
     git config --global gpg.ssh.allowedSignersFile ~/.config/git/allowed-signers
     git config --global commit.gpgsign true
 


### PR DESCRIPTION
there's a mistake in the how to i added to the docs, `user.signingkey` in git config should be to `.pub` public part, not the private part:
https://docs.github.com/en/authentication/managing-commit-signature-verification/telling-git-about-your-signing-key#telling-git-about-your-ssh-key