### PR TITLE
add lfric version number update

### DIFF
--- a/source/Reviewers/releases/lfric_apps_release.rst
+++ b/source/Reviewers/releases/lfric_apps_release.rst
@@ -94,3 +94,21 @@ LFRic Release
 
 * Open a PR for each and with a reviewer, follow the
   :ref:`review process <github-releases>`
+
+* Finally, the first PR post-release for both LFRic Apps and Core should now be
+  made to update the version identifier back to False. This is done in:
+
+  * LFRic Apps - ``science/shared/source/utilities/lfric_apps_version_mod.f90``
+  * LFRic Core - ``lfric_core/infrastructure/source/utilities/lfric_core_version_mod.f90``
+
+  In each of these, update the ``lfric_*_release_version`` parameter such that
+  it is now ``.false.``.
+  Open a new PR for each and have them committed before announcing the release.
+
+  .. note::
+
+    The ``lfric_*_release_version`` parameter will always be ``.true.`` for the
+    ``stable`` branch and therefore any branches branched from here. Anyone
+    looking to utilise this functionality on a version branch will need to
+    update the variable for themselves.
+

--- a/source/Reviewers/releases/lfric_apps_release.rst
+++ b/source/Reviewers/releases/lfric_apps_release.rst
@@ -103,7 +103,8 @@ LFRic Release
 
   In each of these, update the ``lfric_*_release_version`` parameter such that
   it is now ``.false.``.
-  Open a new PR for each and have them committed before announcing the release.
+  Open a new PR for each targetting ``main`` and have them committed before
+  announcing the release.
 
   .. note::
 


### PR DESCRIPTION
# PR Summary

Code Reviewer: @cameronbateman-mo 

<!-- To be completed by the developer -->

This adds a new step for the lfric release to change the version_mod boolean back to true on the main branch once the release is completed.

- linked MetOffice/SimSys_Scripts#232

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] I have locally built the documentation successfully, and the output of changed sections is as expected

# Code Review

- [ ] The changes are coherent and valid
