### PR TITLE
Add warning about git credentials storage in clear text

### DIFF
--- a/source/WorkingPractices/gh_authorisation.rst
+++ b/source/WorkingPractices/gh_authorisation.rst
@@ -232,6 +232,12 @@ git to use it:
     chmod 0600 ~/.git-credentials
     git config --global credential.helper 'store --file ~/.git-credentials'
 
+.. warning::
+    Beware that this setup will store all credentials in clear text, including
+    passwords that you might use for other git-based services in the future.
+    See https://git-scm.com/doc/credential-helpers for further details and
+    other options.
+
 Next, `create a Classic Token
 <https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#creating-a-personal-access-token-classic>`_.
 To read from or write to a repository, ensure your token has at least the


### PR DESCRIPTION
# PR Summary

Code Reviewer: @yaswant 

Add a warning that using git credentials storage as per the instructions can lead to passwords being stored in clear text; closes #646.

## Code Quality Checklist

- [x] I have performed a self-review of my own code
- [x] I have locally built the documentation successfully, and the output of changed sections is as expected

# Code Review

- [ ] The changes are coherent and valid
